### PR TITLE
mcp: Update run command to build local binary first

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -33,7 +33,7 @@
   "servers": {
     "luno": {
       "command": "sh",
-      "args": ["-c", "cd ${workspaceFolder} && make build && ./luno-mcp"], // Build and run local binary, rather than docker image, so that we can test changes locally.
+        "args": ["-c", "cd ${workspaceFolder} && make build && exec ./luno-mcp"], // Build and run local binary, so that we can test changes locally.
       "env": {
         "LUNO_API_KEY_ID": "${input:luno_api_key_id}",
         "LUNO_API_SECRET": "${input:luno_api_secret}"

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -32,8 +32,8 @@
   ],
   "servers": {
     "luno": {
-      "command": "luno-mcp", // Use local binary, rather than docker image, so that we can test changes locally.
-      "args": [],
+      "command": "sh",
+      "args": ["-c", "cd ${workspaceFolder} && make build && ./luno-mcp"], // Build and run local binary, rather than docker image, so that we can test changes locally.
       "env": {
         "LUNO_API_KEY_ID": "${input:luno_api_key_id}",
         "LUNO_API_SECRET": "${input:luno_api_secret}"


### PR DESCRIPTION
### Changed
- mcp config to build local binary before running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated server configuration to automatically build and run the local binary when starting the server. No changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->