### PR TITLE
docker-publish: Separate cache from actual image tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,11 +52,11 @@ jobs:
           {
             echo "cache_from<<EOF"
             echo "type=gha"
-            [ "${{ github.event_name }}" != "pull_request" ] && echo "type=registry,ref=ghcr.io/${{ github.repository }}:buildcache"
+            [ "${{ github.event_name }}" != "pull_request" ] && echo "type=registry,ref=ghcr.io/${{ github.repository }}/cache"
             echo "EOF"
             echo "cache_to<<EOF"
             echo "type=gha,mode=max"
-            [ "${{ github.event_name }}" != "pull_request" ] && echo "type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max"
+            [ "${{ github.event_name }}" != "pull_request" ] && echo "type=registry,ref=ghcr.io/${{ github.repository }}/cache,mode=max"
             echo "EOF"
           } >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
### Changed
- Image tags
  - Instead of using `:buildcache` as a tag, changed to /cache which creates a separate package for caching purposes.
  - Separated cache from main image: This way, the cache will be stored as ghcr.io/luno/luno-mcp/cache rather than ghcr.io/luno/luno-mcp:buildcache.