### PR TITLE
readme: Add glama badge to allow scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,6 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/luno/luno-mcp)](https://goreportcard.com/report/github.com/luno/luno-mcp)
 [![GoDoc](https://godoc.org/github.com/luno/luno-mcp?status.svg)](https://godoc.org/github.com/luno/luno-mcp)
 
-
-<a href="https://glama.ai/mcp/servers/@luno/luno-mcp">
-  <img width="380" height="200" src="https://glama.ai/mcp/servers/@luno/luno-mcp/badge" />
-</a>
-
 A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that provides access to the Luno cryptocurrency exchange API.
 
 This server enables integration with VS Code's Copilot and other MCP-compatible clients, providing contextual information and functionality related to the Luno cryptocurrency exchange.


### PR DESCRIPTION
### Added
- Glama badge
- glama.json to allow for MCP scanning from https://glama.ai/mcp/servers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a badge in the README linking to the MCP server page on glama.ai.

- **Chores**
  - Introduced a new configuration file specifying schema information and maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->