### PR TITLE
internal/config: Set User-Agent for Luno API calls

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,7 +64,7 @@ func Load(domainOverride string) (*Config, error) {
 	}
 
 	// Create Luno client
-	client := luno.NewClient()
+	client := luno.NewClient(luno.WithUserAgent("Luno MCP Server"))
 	if domain != DefaultLunoDomain {
 		client.SetBaseURL(fmt.Sprintf("https://%s", domain))
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -180,6 +180,13 @@ func TestLoad(t *testing.T) {
 			if cfg.LunoClient == nil {
 				t.Error("Expected LunoClient to be non-nil")
 			}
+
+			// TODO: Update this assertion when luno-go provides a way to inspect User-Agent
+			// For now, this is a placeholder to indicate the intent.
+			// Example of a possible future assertion:
+			// if cfg.LunoClient.UserAgent() != "Luno MCP Server" {
+			// 	t.Errorf("Expected User-Agent to be 'Luno MCP Server', got %q", cfg.LunoClient.UserAgent())
+			// }
 		})
 	}
 }


### PR DESCRIPTION
This change updates luno-mcp to set a custom User-Agent string ("Luno MCP Server") when initializing the Luno API client.

This assumes that the luno-go library will be updated to accept a WithUserAgent option in its NewClient function. A placeholder test has been added to verify this configuration, which will need to be updated once luno-go provides a way to inspect the User-Agent.