### PR TITLE
github/workflows: Don't run docker-publish unless on main

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,9 +7,8 @@ on:
       - main
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - main
+    paths:
+      - '.github/workflows/docker-publish.yml'
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
### Changed
Don't run docker-publish unless on main, or the file itself is changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow triggers so that the Docker publish workflow now only runs on pushes affecting the workflow file itself.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->