### PR TITLE
Fix Docker publish workflow trigger paths

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,11 @@ on:
     tags:
       - 'v*'
     paths:
+      - 'cmd/**'
+      - 'internal/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
       - '.github/workflows/docker-publish.yml'
 
 jobs:


### PR DESCRIPTION
## Summary
- Fixed Docker publish workflow to trigger on actual code changes, not just workflow file changes
- Added paths filter for cmd/, internal/, go.mod, go.sum, and Dockerfile
- This ensures Docker images are published when pushing code changes to main branch

## Test plan
- [x] Workflow file syntax is valid (pre-commit hooks passed)
- [ ] Next push to main with code changes should trigger Docker publish
- [ ] PR builds should still only verify, not publish

AI::Assisted