### PR TITLE
github: Revert SHA hash pinning for GitHub Actions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,17 +24,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414fa7e23de73c4e6  # v3.2.0
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8026d2bc3645ea78b0d2544766a1225eb5691f89  # v3.7.1
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to the Container registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567  # v3.3.0
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81  # v5.5.1
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -65,7 +65,7 @@ jobs:
           } >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75  # v6.9.0
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -15,14 +15,14 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ["1.23", "1.24", "1"]
+        go-version: ["1.24", "1"]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+        uses: actions/checkout@v4
 
       - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
           cache: true

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5  # v5.5.0
+        uses: actions/setup-go@v5
         with:
           go-version: '1.25'
 
@@ -25,4 +25,4 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name != 'pull_request' && env.SONAR_TOKEN != '')
-        uses: SonarSource/sonarqube-scan-action@1a6d90ebcb0e6a6b1d87e37ba693fe453195ae25  # v5.3.1
+        uses: SonarSource/sonarqube-scan-action@v5.3.0


### PR DESCRIPTION
## Summary
• Reverts SHA hash pinning for GitHub Actions back to version tags
• Improves visibility of action versions when using Renovate
• Follows GitHub Action authors' recommendations for version pinning

## Background
The previous commit c17101e pinned GitHub Actions to specific SHA hashes for enhanced security. However, this approach makes it difficult to see which versions are being used with Renovate, and version tags are actually the recommended approach by GitHub Action authors.

## Changes
- Reverted `.github/workflows/docker-publish.yml` to use version tags
- Reverted `.github/workflows/go-tests.yml` to use version tags  
- Reverted `.github/workflows/sonar.yaml` to use version tags

AI:Assisted