### PR TITLE
workflows: Fix SonarCloud authentication for bot PRs

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -24,5 +24,9 @@ jobs:
       - name: Upload coverage reports to Sonar
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
         uses: SonarSource/sonarqube-scan-action@v5.3.1
+        with:
+          args: >
+            -Dsonar.token=${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- Add GITHUB_TOKEN environment variable to SonarQube scan step
- Pass SONAR_TOKEN explicitly via args parameter
- Fixes HTTP 401 authentication errors when bot PRs (Renovate/Dependabot) trigger SonarCloud scans

## Test plan
- [ ] Verify bot PRs no longer fail with SonarCloud authentication errors
- [ ] Confirm regular PRs continue to work with SonarCloud scans
- [ ] Check that coverage reports are still uploaded correctly

🤖 Generated with [Claude Code](https://claude.ai/code)