### PR TITLE
github/workflows: Add timeouts

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -10,6 +10,7 @@ jobs:
   tests:
     name: Go Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     permissions:
       contents: read
 

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -10,7 +10,7 @@ jobs:
   tests:
     name: Go Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 10
     permissions:
       contents: read
 

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -10,6 +10,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -10,7 +10,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
- Add timeouts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Set explicit execution timeouts for CI workflows to improve reliability and prevent runaway jobs.
  - Docker build-and-publish pipeline now limited to 25 minutes.
  - Go test job now limited to 10 minutes.
  - Sonar analysis build now limited to 15 minutes.
  - No changes to application behaviour or features; only CI pipeline execution timeouts adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->