### PR TITLE
release: Add Homebrew distribution via luno/luno-mcp-homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Generate checksums
         working-directory: dist
-        run: sha256sum *.tar.gz > checksums.txt
+        run: sha256sum -- ./*.tar.gz > checksums.txt
 
       - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: darwin
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: "0"
+        run: |
+          go build -ldflags="-s -w" -o luno-mcp ./cmd/server
+          tar czf luno-mcp-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz luno-mcp
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: luno-mcp-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: luno-mcp-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: dist
+        run: sha256sum *.tar.gz > checksums.txt
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+
+      - name: Trigger Homebrew tap update
+        continue-on-error: true
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_PAT }}
+          repository: luno/luno-mcp-homebrew
+          event-type: new-release
+          client-payload: '{"version": "${{ github.ref_name }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,64 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
+  schedule:
+    - cron: '0 9 * * *'  # 9am UTC daily
+  workflow_dispatch:
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release
   cancel-in-progress: false
 
 jobs:
+  prepare:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for new commits and determine version
+        id: check
+        run: |
+          set -eo pipefail
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          COMMITS_SINCE=$(git rev-list "${LATEST_TAG}..HEAD" --count)
+
+          if [ "$COMMITS_SINCE" -eq 0 ]; then
+            echo "No new commits since ${LATEST_TAG}, skipping release"
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          VERSION="${LATEST_TAG#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          NEW_VERSION="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+
+          echo "Latest: ${LATEST_TAG} → releasing: ${NEW_VERSION} (${COMMITS_SINCE} new commits)"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.check.outputs.version }}"
+          git push origin "${{ steps.check.outputs.version }}"
+
   build:
     name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
+    needs: prepare
+    if: needs.prepare.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -49,7 +96,7 @@ jobs:
 
   release:
     name: Create Release
-    needs: build
+    needs: [prepare, build]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -66,6 +113,7 @@ jobs:
 
       - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
+          tag_name: ${{ needs.prepare.outputs.version }}
           files: dist/*
           generate_release_notes: true
 
@@ -76,4 +124,4 @@ jobs:
           token: ${{ secrets.HOMEBREW_TAP_PAT }}
           repository: luno/luno-mcp-homebrew
           event-type: new-release
-          client-payload: '{"version": "${{ github.ref_name }}"}'
+          client-payload: '{"version": "${{ needs.prepare.outputs.version }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,14 +64,14 @@ jobs:
         working-directory: dist
         run: sha256sum *.tar.gz > checksums.txt
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           files: dist/*
           generate_release_notes: true
 
       - name: Trigger Homebrew tap update
         continue-on-error: true
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.HOMEBREW_TAP_PAT }}
           repository: luno/luno-mcp-homebrew

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,26 +151,25 @@ docker run --env-file .env -p 8080:8080 luno-mcp --transport sse --sse-address 0
 
 ## Release Process
 
-Releases are triggered by pushing a semver tag. This kicks off two automated publishing workflows.
+Releases are fully automated and run on a daily schedule (9am UTC). A release is only created if there are new commits since the last tag — so merging to `main` is all that's needed. No manual tagging required.
 
-### Publishing a release
-
-```bash
-git tag v0.3.0
-git push origin v0.3.0
-```
+The workflow can also be triggered manually via the [Actions tab](https://github.com/luno/luno-mcp/actions/workflows/release.yml) if you need to release outside the schedule.
 
 ### What happens automatically
 
-#### Docker image (`docker-publish.yml`)
-
-Builds and pushes a multi-arch image (`linux/amd64`, `linux/arm64`) to `ghcr.io/luno/luno-mcp`. Tags the image with the semver version and `latest`.
-
 #### Binaries + Homebrew (`release.yml`)
 
-1. Builds binaries for `darwin/arm64`, `darwin/amd64`, `linux/amd64`, and `linux/arm64`
-2. Creates a GitHub release with the binaries as `.tar.gz` assets and a `checksums.txt`
-3. Dispatches a `new-release` event to the [luno/luno-mcp-homebrew](https://github.com/luno/luno-mcp-homebrew) tap repo, which auto-updates the formula with the new version and SHA256s
+Runs daily at 9am UTC (or on manual trigger):
+
+1. Checks for commits since the last release tag — skips if there are none
+2. Bumps the patch version and creates a new tag (e.g. `v0.2.1` → `v0.2.2`)
+3. Builds binaries for `darwin/arm64`, `darwin/amd64`, `linux/amd64`, and `linux/arm64`
+4. Creates a GitHub release with the binaries as `.tar.gz` assets and a `checksums.txt`
+5. Dispatches a `new-release` event to the [luno/luno-mcp-homebrew](https://github.com/luno/luno-mcp-homebrew) tap repo, which auto-updates the formula with the new version and SHA256s
+
+#### Docker image (`docker-publish.yml`)
+
+Triggers on pushes to `main` and on `v*` tags. Builds and pushes a multi-arch image (`linux/amd64`, `linux/arm64`) to `ghcr.io/luno/luno-mcp`, tagged with the semver version and `latest`.
 
 ### Prerequisites for the release workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ Runs daily at 9am UTC (or on manual trigger):
 1. Checks for commits since the last release tag — skips if there are none
 2. Bumps the patch version and creates a new tag (e.g. `v0.2.1` → `v0.2.2`)
 3. Builds binaries for `darwin/arm64`, `darwin/amd64`, `linux/amd64`, and `linux/arm64`
-4. Creates a GitHub release with the binaries as `.tar.gz` assets and a `checksums.txt`
+4. Creates a GitHub release with the binaries as `.tar.gz` assets and `checksums.txt`
 5. Dispatches a `new-release` event to the [luno/luno-mcp-homebrew](https://github.com/luno/luno-mcp-homebrew) tap repo, which auto-updates the formula with the new version and SHA256s
 
 #### Docker image (`docker-publish.yml`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,42 @@ docker run --env-file .env -p 8080:8080 luno-mcp --transport sse --sse-address 0
 - Ensure error handling is comprehensive
 - Keep functions focused and modular
 
+## Release Process
+
+Releases are triggered by pushing a semver tag. This kicks off two automated publishing workflows.
+
+### Publishing a release
+
+```bash
+git tag v0.3.0
+git push origin v0.3.0
+```
+
+### What happens automatically
+
+#### Docker image (`docker-publish.yml`)
+
+Builds and pushes a multi-arch image (`linux/amd64`, `linux/arm64`) to `ghcr.io/luno/luno-mcp`. Tags the image with the semver version and `latest`.
+
+#### Binaries + Homebrew (`release.yml`)
+
+1. Builds binaries for `darwin/arm64`, `darwin/amd64`, `linux/amd64`, and `linux/arm64`
+2. Creates a GitHub release with the binaries as `.tar.gz` assets and a `checksums.txt`
+3. Dispatches a `new-release` event to the [luno/luno-mcp-homebrew](https://github.com/luno/luno-mcp-homebrew) tap repo, which auto-updates the formula with the new version and SHA256s
+
+### Prerequisites for the release workflow
+
+The `HOMEBREW_TAP_PAT` secret must be set in this repo's GitHub settings. It should be a fine-grained PAT with `Contents: write` permission on the `luno/luno-mcp-homebrew` repo.
+
+### Installing via Homebrew (macOS)
+
+Once a release is published, users can install with:
+
+```bash
+brew tap luno/luno-mcp-homebrew
+brew install luno-mcp
+```
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the project's [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -379,41 +379,6 @@ sudo mv luno-mcp /usr/local/bin/
 </details>
 
 <details>
-<summary>Homebrew (macOS)</summary>
-
-Install via [Homebrew](https://brew.sh) using the [luno/luno-mcp-homebrew](https://github.com/luno/luno-mcp-homebrew) tap:
-
-```bash
-brew tap luno/luno-mcp-homebrew
-brew install luno-mcp
-```
-
-Then configure your MCP client:
-
-```json
-{
-  "mcpServers": {
-    "luno": {
-      "command": "luno-mcp",
-      "args": ["--transport", "stdio"],
-      "env": {
-        "LUNO_API_KEY_ID": "YOUR_API_KEY_ID",
-        "LUNO_API_SECRET": "YOUR_API_SECRET"
-      }
-    }
-  }
-}
-```
-
-Or with Claude Code:
-
-```bash
-claude mcp add luno -e LUNO_API_KEY_ID=YOUR_API_KEY_ID -e LUNO_API_SECRET=YOUR_API_SECRET -- luno-mcp
-```
-
-</details>
-
-<details>
 <summary>Docker</summary>
 
 Use the standard config above, or run directly:

--- a/README.md
+++ b/README.md
@@ -167,6 +167,41 @@ sudo mv luno-mcp /usr/local/bin/
 </details>
 
 <details>
+<summary>Homebrew (macOS)</summary>
+
+Install via [Homebrew](https://brew.sh) using the [luno/luno-mcp-homebrew](https://github.com/luno/luno-mcp-homebrew) tap:
+
+```bash
+brew tap luno/luno-mcp-homebrew
+brew install luno-mcp
+```
+
+Then configure your MCP client:
+
+```json
+{
+  "mcpServers": {
+    "luno": {
+      "command": "luno-mcp",
+      "args": ["--transport", "stdio"],
+      "env": {
+        "LUNO_API_KEY_ID": "YOUR_API_KEY_ID",
+        "LUNO_API_SECRET": "YOUR_API_SECRET"
+      }
+    }
+  }
+}
+```
+
+Or with Claude Code:
+
+```bash
+claude mcp add luno -e LUNO_API_KEY_ID=YOUR_API_KEY_ID -e LUNO_API_SECRET=YOUR_API_SECRET -- luno-mcp
+```
+
+</details>
+
+<details>
 <summary>Docker</summary>
 
 Use the standard config above, or run directly:
@@ -339,6 +374,41 @@ Optionally make it available system-wide:
 
 ```bash
 sudo mv luno-mcp /usr/local/bin/
+```
+
+</details>
+
+<details>
+<summary>Homebrew (macOS)</summary>
+
+Install via [Homebrew](https://brew.sh) using the [luno/luno-mcp-homebrew](https://github.com/luno/luno-mcp-homebrew) tap:
+
+```bash
+brew tap luno/luno-mcp-homebrew
+brew install luno-mcp
+```
+
+Then configure your MCP client:
+
+```json
+{
+  "mcpServers": {
+    "luno": {
+      "command": "luno-mcp",
+      "args": ["--transport", "stdio"],
+      "env": {
+        "LUNO_API_KEY_ID": "YOUR_API_KEY_ID",
+        "LUNO_API_SECRET": "YOUR_API_SECRET"
+      }
+    }
+  }
+}
+```
+
+Or with Claude Code:
+
+```bash
+claude mcp add luno -e LUNO_API_KEY_ID=YOUR_API_KEY_ID -e LUNO_API_SECRET=YOUR_API_SECRET -- luno-mcp
 ```
 
 </details>


### PR DESCRIPTION
## Summary

- Adds `release.yml` CI workflow that builds native binaries for `darwin/arm64`, `darwin/amd64`, `linux/amd64`, and `linux/arm64` on tag push, creates a GitHub release with `.tar.gz` assets and `checksums.txt`, then dispatches to [luno/luno-mcp-homebrew](https://github.com/luno/luno-mcp-homebrew) to auto-update the Homebrew formula
- Adds Homebrew install instructions to README alongside existing Docker/source methods
- Documents the full release process (Docker + Homebrew) in CONTRIBUTING.md

## Pre-requisite

Add `HOMEBREW_TAP_PAT` to this repo's secrets — a fine-grained PAT with `Contents: write` on `luno/luno-mcp-homebrew`. Without it, the tap dispatch step will fail (non-blocking — the release itself still succeeds due to `continue-on-error: true`).

## Test plan

- [ ] Verify `release.yml` triggers on a `v*` tag push
- [ ] Confirm GitHub release is created with 4 platform tarballs + `checksums.txt`
- [ ] Confirm `luno/luno-mcp-homebrew` formula is updated with correct version and SHAs
- [ ] Test `brew tap luno/luno-mcp-homebrew && brew install luno-mcp` on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Homebrew installation option for macOS users.
  * Automated cross-platform binary releases for macOS and Linux (ARM64 and x86-64 architectures).

* **Documentation**
  * Added Homebrew installation and configuration instructions to README.
  * Documented release process procedures in contributor guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->