### PR TITLE
release: Trigger from GitHub Release publish event

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,64 +1,16 @@
 name: Release
 
 on:
-  schedule:
-    - cron: '0 9 * * *'  # 9am UTC daily
-  workflow_dispatch:
+  release:
+    types: [published]
 
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  prepare:
-    name: Prepare Release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      should_release: ${{ steps.check.outputs.should_release }}
-      version: ${{ steps.check.outputs.version }}
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Check for new commits and determine version
-        id: check
-        run: |
-          set -eo pipefail
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
-          COMMITS_SINCE=$(git rev-list "${LATEST_TAG}..HEAD" --count)
-
-          if [ "$COMMITS_SINCE" -eq 0 ]; then
-            echo "No new commits since ${LATEST_TAG}, skipping release"
-            echo "should_release=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          VERSION="${LATEST_TAG#v}"
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          PATCH=$(echo "$VERSION" | cut -d. -f3)
-          NEW_VERSION="v${MAJOR}.${MINOR}.$((PATCH + 1))"
-
-          echo "Latest: ${LATEST_TAG} → releasing: ${NEW_VERSION} (${COMMITS_SINCE} new commits)"
-          echo "should_release=true" >> "$GITHUB_OUTPUT"
-          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Create and push tag
-        if: steps.check.outputs.should_release == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "${{ steps.check.outputs.version }}"
-          git push origin "${{ steps.check.outputs.version }}"
-
   build:
     name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
-    needs: prepare
-    if: needs.prepare.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -94,9 +46,9 @@ jobs:
           name: luno-mcp-${{ matrix.goos }}-${{ matrix.goarch }}
           path: luno-mcp-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
 
-  release:
-    name: Create Release
-    needs: [prepare, build]
+  publish:
+    name: Publish Release Assets
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -111,17 +63,19 @@ jobs:
         working-directory: dist
         run: sha256sum -- ./*.tar.gz > checksums.txt
 
-      - uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+      - name: Upload assets to release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
-          tag_name: ${{ needs.prepare.outputs.version }}
+          tag_name: ${{ github.event.release.tag_name }}
           files: dist/*
-          generate_release_notes: true
 
       - name: Trigger Homebrew tap update
         continue-on-error: true
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.HOMEBREW_TAP_PAT }}
-          repository: luno/luno-mcp-homebrew
+          repository: luno/homebrew-luno-mcp
           event-type: new-release
-          client-payload: '{"version": "${{ needs.prepare.outputs.version }}"}'
+          client-payload: '{"version": "${{ github.event.release.tag_name }}"}'
+
+      # Docker is published automatically by docker-publish.yml, which triggers on v* tag pushes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   build:
     name: Build ${{ matrix.goos }}-${{ matrix.goarch }}
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,25 +151,30 @@ docker run --env-file .env -p 8080:8080 luno-mcp --transport sse --sse-address 0
 
 ## Release Process
 
-Releases are fully automated and run on a daily schedule (9am UTC). A release is only created if there are new commits since the last tag — so merging to `main` is all that's needed. No manual tagging required.
+Releases are triggered by publishing a GitHub Release. The release tag determines the version — no other configuration is needed.
 
-The workflow can also be triggered manually via the [Actions tab](https://github.com/luno/luno-mcp/actions/workflows/release.yml) if you need to release outside the schedule.
+### Steps to release
+
+1. Go to [Releases](https://github.com/luno/luno-mcp/releases) and click **Draft a new release**
+2. Enter the new version as the tag (e.g. `v1.3.0`), targeting `main`
+3. Write release notes describing the changes
+4. Click **Publish release**
 
 ### What happens automatically
 
+Publishing a release fires two workflows in parallel:
+
 #### Binaries + Homebrew (`release.yml`)
 
-Runs daily at 9am UTC (or on manual trigger):
+Triggered by the `release: published` event:
 
-1. Checks for commits since the last release tag — skips if there are none
-2. Bumps the patch version and creates a new tag (e.g. `v0.2.1` → `v0.2.2`)
-3. Builds binaries for `darwin/arm64`, `darwin/amd64`, `linux/amd64`, and `linux/arm64`
-4. Creates a GitHub release with the binaries as `.tar.gz` assets and `checksums.txt`
-5. Dispatches a `new-release` event to the [luno/luno-mcp-homebrew](https://github.com/luno/luno-mcp-homebrew) tap repo, which auto-updates the formula with the new version and SHA256s
+1. Builds binaries for `darwin/arm64`, `darwin/amd64`, `linux/amd64`, and `linux/arm64`
+2. Uploads the binaries as `.tar.gz` assets and a `checksums.txt` to the release
+3. Dispatches a `new-release` event to the [luno/luno-mcp-homebrew](https://github.com/luno/luno-mcp-homebrew) tap repo, which auto-updates the formula with the new version and SHA256s
 
 #### Docker image (`docker-publish.yml`)
 
-Triggers on pushes to `main` and on `v*` tags. Builds and pushes a multi-arch image (`linux/amd64`, `linux/arm64`) to `ghcr.io/luno/luno-mcp`, tagged with the semver version and `latest`.
+Triggered by the `v*` tag push that GitHub creates when the release is published. Builds and pushes a multi-arch image (`linux/amd64`, `linux/arm64`) to `ghcr.io/luno/luno-mcp`, tagged with the semver version and `latest`.
 
 ### Prerequisites for the release workflow
 
@@ -180,7 +185,7 @@ The `HOMEBREW_TAP_PAT` secret must be set in this repo's GitHub settings. It sho
 Once a release is published, users can install with:
 
 ```bash
-brew tap luno/luno-mcp-homebrew
+brew tap luno/luno-mcp
 brew install luno-mcp
 ```
 


### PR DESCRIPTION
## Summary

- Replaces the daily scheduled auto-release (and `workflow_dispatch` UI trigger) with a `release: published` event trigger — publishing a GitHub Release is now the sole release mechanism
- Version is taken from the release tag you set in the GitHub UI; no auto patch-bump logic
- Renames the Homebrew dispatch target from `luno/luno-mcp-homebrew` → `luno/homebrew-luno-mcp` following the tap repo rename
- Updates `CONTRIBUTING.md` with the new release steps and corrected `brew tap luno/luno-mcp` instruction

## Release flow after this change

```
Publish GitHub Release (e.g. v1.4.0)
    │
    ├──▶ push event (v* tag) → docker-publish.yml → ghcr.io image
    │
    └──▶ release: published → release.yml
              ├── build (4 platform binaries)
              └── publish → uploads assets to release
                          → dispatches to homebrew-luno-mcp
```

## Test plan

- [ ] Merge luno/homebrew-luno-mcp#1 first (tap name update)
- [ ] Publish a test release and verify all three destinations receive the new version: GitHub release assets, `ghcr.io` Docker image, and Homebrew formula


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation to reflect new GitHub Release-based workflow for publishing updates.
  * Updated Homebrew tap reference from `luno/luno-mcp-homebrew` to `luno/luno-mcp`.

* **Chores**
  * Streamlined release pipeline by simplifying CI/CD workflows and automations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->