### PR TITLE
feat: add claude-desktop-install.sh for zero-dependency setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,10 +69,10 @@ LUNO_API_DOMAIN=api.staging.luno.com  # Optional: Override API Domain
 To install and configure Claude Desktop against the staging API with write operations enabled:
 
 ```bash
-LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> \
+curl -fsSL https://raw.githubusercontent.com/luno/luno-mcp/main/claude-desktop-install.sh | \
+  LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> \
   LUNO_API_DOMAIN=api.staging.luno.com \
-  ALLOW_WRITE_OPERATIONS=true \
-  curl -fsSL https://raw.githubusercontent.com/luno/luno-mcp/main/claude-desktop-install.sh | sh
+  ALLOW_WRITE_OPERATIONS=true sh
 ```
 
 Restart Claude Desktop after running this. To revert to production, re-run without the staging env vars.
@@ -183,7 +183,7 @@ Triggered by the `release: published` event:
 
 1. Builds binaries for `darwin/arm64`, `darwin/amd64`, `linux/amd64`, and `linux/arm64`
 2. Uploads the binaries as `.tar.gz` assets and a `checksums.txt` to the release
-3. Dispatches a `new-release` event to the [luno/luno-mcp-homebrew](https://github.com/luno/luno-mcp-homebrew) tap repo, which auto-updates the formula with the new version and SHA256s
+3. Dispatches a `new-release` event to the [luno/homebrew-luno-mcp](https://github.com/luno/homebrew-luno-mcp) tap repo, which auto-updates the formula with the new version and SHA256s
 
 #### Docker image (`docker-publish.yml`)
 
@@ -191,7 +191,7 @@ Triggered by the `v*` tag push that GitHub creates when the release is published
 
 ### Prerequisites for the release workflow
 
-The `HOMEBREW_TAP_PAT` secret must be set in this repo's GitHub settings. It should be a fine-grained PAT with `Contents: write` permission on the `luno/luno-mcp-homebrew` repo.
+The `HOMEBREW_TAP_PAT` secret must be set in this repo's GitHub settings. It should be a fine-grained PAT with `Contents: write` permission on the `luno/homebrew-luno-mcp` repo.
 
 ### Installing via Homebrew (macOS)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,19 @@ LUNO_API_DOMAIN=api.staging.luno.com  # Optional: Override API Domain
 
 **Note**: When using the MCP server with VS Code or other MCP clients, credentials are provided through the client's input system. The `.env` file and environment variables are only needed for direct development when running `go run ./cmd/server` or the binary directly.
 
+### Testing with Claude Desktop (staging)
+
+To install and configure Claude Desktop against the staging API with write operations enabled:
+
+```bash
+LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> \
+  LUNO_API_DOMAIN=api.staging.luno.com \
+  ALLOW_WRITE_OPERATIONS=true \
+  curl -fsSL https://raw.githubusercontent.com/luno/luno-mcp/main/claude-desktop-install.sh | sh
+```
+
+Restart Claude Desktop after running this. To revert to production, re-run without the staging env vars.
+
 ### Running the server
 
 #### Standard I/O mode (default)

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ claude mcp add luno -e LUNO_API_KEY_ID=YOUR_API_KEY_ID -e LUNO_API_SECRET=YOUR_A
 One-line install and configure (macOS):
 
 ```bash
-LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> \
-  curl -fsSL https://raw.githubusercontent.com/luno/luno-mcp/main/claude-desktop-install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/luno/luno-mcp/main/claude-desktop-install.sh | \
+  LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> sh
 ```
 
 Or add the standard config to your `claude_desktop_config.json` manually ([setup guide](https://modelcontextprotocol.io/quickstart/user)).
@@ -176,10 +176,10 @@ sudo mv luno-mcp /usr/local/bin/
 <details>
 <summary>Homebrew (macOS)</summary>
 
-Install via [Homebrew](https://brew.sh) using the [luno/luno-mcp-homebrew](https://github.com/luno/luno-mcp-homebrew) tap:
+Install via [Homebrew](https://brew.sh) using the [luno/homebrew-luno-mcp](https://github.com/luno/homebrew-luno-mcp) tap:
 
 ```bash
-brew tap luno/luno-mcp-homebrew
+brew tap luno/luno-mcp
 brew install luno-mcp
 ```
 
@@ -279,8 +279,8 @@ claude mcp add luno -e LUNO_API_KEY_ID=YOUR_API_KEY_ID -e LUNO_API_SECRET=YOUR_A
 One-line install and configure (macOS):
 
 ```bash
-LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> \
-  curl -fsSL https://raw.githubusercontent.com/luno/luno-mcp/main/claude-desktop-install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/luno/luno-mcp/main/claude-desktop-install.sh | \
+  LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> sh
 ```
 
 Or add the standard config to your `claude_desktop_config.json` manually ([setup guide](https://modelcontextprotocol.io/quickstart/user)).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,14 @@ claude mcp add luno -e LUNO_API_KEY_ID=YOUR_API_KEY_ID -e LUNO_API_SECRET=YOUR_A
 <details>
 <summary>Claude Desktop</summary>
 
-Add to your `claude_desktop_config.json` ([setup guide](https://modelcontextprotocol.io/quickstart/user)) using the standard config above.
+One-line install and configure (macOS):
+
+```bash
+LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> \
+  curl -fsSL https://raw.githubusercontent.com/luno/luno-mcp/main/claude-desktop-install.sh | sh
+```
+
+Or add the standard config to your `claude_desktop_config.json` manually ([setup guide](https://modelcontextprotocol.io/quickstart/user)).
 
 </details>
 
@@ -269,7 +276,14 @@ claude mcp add luno -e LUNO_API_KEY_ID=YOUR_API_KEY_ID -e LUNO_API_SECRET=YOUR_A
 <details>
 <summary>Claude Desktop</summary>
 
-Add to your `claude_desktop_config.json` ([setup guide](https://modelcontextprotocol.io/quickstart/user)) using the standard config above.
+One-line install and configure (macOS):
+
+```bash
+LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> \
+  curl -fsSL https://raw.githubusercontent.com/luno/luno-mcp/main/claude-desktop-install.sh | sh
+```
+
+Or add the standard config to your `claude_desktop_config.json` manually ([setup guide](https://modelcontextprotocol.io/quickstart/user)).
 
 </details>
 

--- a/claude-desktop-install.sh
+++ b/claude-desktop-install.sh
@@ -102,8 +102,13 @@ p = os.environ["CLAUDE_DESKTOP_CONFIG"]
 try:
     with open(p) as f:
         c = json.load(f)
-except (FileNotFoundError, json.JSONDecodeError):
+except FileNotFoundError:
     c = {}
+except json.JSONDecodeError as e:
+    raise SystemExit(f"error: {p} contains invalid JSON ({e}); fix it before re-running")
+
+if not isinstance(c, dict):
+    raise SystemExit(f"error: {p} must contain a JSON object at the top level")
 
 env = {
     "LUNO_API_KEY_ID": os.environ["LUNO_API_KEY_ID"],
@@ -114,19 +119,27 @@ if os.environ.get("LUNO_API_DOMAIN"):
 if os.environ.get("ALLOW_WRITE_OPERATIONS"):
     env["ALLOW_WRITE_OPERATIONS"] = os.environ["ALLOW_WRITE_OPERATIONS"]
 
-c.setdefault("mcpServers", {})["luno"] = {
+mcp_servers = c.setdefault("mcpServers", {})
+if not isinstance(mcp_servers, dict):
+    raise SystemExit(f"error: mcpServers in {p} must be a JSON object")
+
+mcp_servers["luno"] = {
     "command": os.environ["INSTALL_PATH"],
     "args": ["--transport", "stdio"],
     "env": env,
 }
 
-with open(p, "w") as f:
+fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+with os.fdopen(fd, "w") as f:
     json.dump(c, f, indent=2)
     f.write("\n")
+os.chmod(p, 0o600)
 PYEOF
     echo "Claude Desktop configured. Restart Claude Desktop to apply changes."
   else
-    echo "warning: python3 not found — install Python 3 and re-run to configure Claude Desktop" >&2
+    echo "error: python3 is required to configure Claude Desktop but was not found" >&2
+    echo "Install Python 3 from https://www.python.org and re-run." >&2
+    exit 1
   fi
 fi
 
@@ -136,7 +149,7 @@ if [ -z "$LUNO_API_KEY_ID" ] || [ -z "$LUNO_API_SECRET" ]; then
   echo ""
   echo "To configure Claude Desktop, re-run with your Luno API credentials:"
   echo ""
-  echo "  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/claude-desktop-install.sh | \\"
+  echo "  curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/${REPO}/main/claude-desktop-install.sh | \\"
   echo "    LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> sh"
   echo ""
   echo "Get API keys from: https://www.luno.com/wallet/security/api"

--- a/claude-desktop-install.sh
+++ b/claude-desktop-install.sh
@@ -57,7 +57,8 @@ elif command -v sha256sum >/dev/null 2>&1; then
 elif command -v shasum >/dev/null 2>&1; then
   grep "${TARBALL}" checksums.txt | shasum -a 256 -c --quiet
 else
-  echo "warning: no sha256 tool found, skipping checksum verification" >&2
+  echo "error: no SHA-256 verification tool found; refusing to install unverified download" >&2
+  exit 1
 fi
 
 tar xzf "${TARBALL}"
@@ -68,8 +69,9 @@ INSTALL_DIR="$DEFAULT_INSTALL_DIR"
 
 if [ -w "$INSTALL_DIR" ]; then
   mv "${BINARY}" "${INSTALL_DIR}/${BINARY}"
-elif command -v sudo >/dev/null 2>&1; then
+elif command -v sudo >/dev/null 2>&1 && sudo -v; then
   echo "Installing to ${INSTALL_DIR} (requires sudo)..."
+  sudo mkdir -p "$INSTALL_DIR"
   sudo mv "${BINARY}" "${INSTALL_DIR}/${BINARY}"
   sudo chmod +x "${INSTALL_DIR}/${BINARY}"
 else
@@ -85,60 +87,47 @@ echo "${BINARY} v${VERSION} installed to ${INSTALL_DIR}/${BINARY}"
 # --- Configure Claude Desktop (macOS only, if API keys are provided) ---
 
 if [ "$OS" = "darwin" ] && [ -n "$LUNO_API_KEY_ID" ] && [ -n "$LUNO_API_SECRET" ]; then
-  if [ -f "$CLAUDE_DESKTOP_CONFIG" ]; then
-    # Merge into existing config using Python if available, otherwise append a warning
-    if command -v python3 >/dev/null 2>&1; then
-      python3 - <<PYEOF
+  if command -v python3 >/dev/null 2>&1; then
+    mkdir -p "$(dirname "$CLAUDE_DESKTOP_CONFIG")"
+    CLAUDE_DESKTOP_CONFIG="$CLAUDE_DESKTOP_CONFIG" \
+    LUNO_API_KEY_ID="$LUNO_API_KEY_ID" \
+    LUNO_API_SECRET="$LUNO_API_SECRET" \
+    LUNO_API_DOMAIN="${LUNO_API_DOMAIN:-}" \
+    ALLOW_WRITE_OPERATIONS="${ALLOW_WRITE_OPERATIONS:-}" \
+    INSTALL_PATH="${INSTALL_DIR}/${BINARY}" \
+    python3 - <<'PYEOF'
 import json, os
-p = os.path.expanduser("$CLAUDE_DESKTOP_CONFIG")
-with open(p) as f:
-    c = json.load(f)
+
+p = os.environ["CLAUDE_DESKTOP_CONFIG"]
+try:
+    with open(p) as f:
+        c = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    c = {}
+
 env = {
-    "LUNO_API_KEY_ID": "$LUNO_API_KEY_ID",
-    "LUNO_API_SECRET": "$LUNO_API_SECRET"
+    "LUNO_API_KEY_ID": os.environ["LUNO_API_KEY_ID"],
+    "LUNO_API_SECRET": os.environ["LUNO_API_SECRET"],
 }
-if "$LUNO_API_DOMAIN":
-    env["LUNO_API_DOMAIN"] = "$LUNO_API_DOMAIN"
-if "$ALLOW_WRITE_OPERATIONS":
-    env["ALLOW_WRITE_OPERATIONS"] = "$ALLOW_WRITE_OPERATIONS"
+if os.environ.get("LUNO_API_DOMAIN"):
+    env["LUNO_API_DOMAIN"] = os.environ["LUNO_API_DOMAIN"]
+if os.environ.get("ALLOW_WRITE_OPERATIONS"):
+    env["ALLOW_WRITE_OPERATIONS"] = os.environ["ALLOW_WRITE_OPERATIONS"]
+
 c.setdefault("mcpServers", {})["luno"] = {
-    "command": "$BINARY",
+    "command": os.environ["INSTALL_PATH"],
     "args": ["--transport", "stdio"],
-    "env": env
+    "env": env,
 }
+
 with open(p, "w") as f:
     json.dump(c, f, indent=2)
     f.write("\n")
 PYEOF
-      echo "Claude Desktop configured."
-    else
-      echo "warning: python3 not found — Claude Desktop config not updated automatically" >&2
-    fi
+    echo "Claude Desktop configured. Restart Claude Desktop to apply changes."
   else
-    mkdir -p "$(dirname "$CLAUDE_DESKTOP_CONFIG")"
-    # Build env block, adding optional vars only when set
-    ENV_BLOCK="        \"LUNO_API_KEY_ID\": \"${LUNO_API_KEY_ID}\",
-        \"LUNO_API_SECRET\": \"${LUNO_API_SECRET}\""
-    [ -n "$LUNO_API_DOMAIN" ]         && ENV_BLOCK="${ENV_BLOCK},
-        \"LUNO_API_DOMAIN\": \"${LUNO_API_DOMAIN}\""
-    [ -n "$ALLOW_WRITE_OPERATIONS" ]  && ENV_BLOCK="${ENV_BLOCK},
-        \"ALLOW_WRITE_OPERATIONS\": \"${ALLOW_WRITE_OPERATIONS}\""
-    cat > "$CLAUDE_DESKTOP_CONFIG" <<EOF
-{
-  "mcpServers": {
-    "luno": {
-      "command": "${BINARY}",
-      "args": ["--transport", "stdio"],
-      "env": {
-${ENV_BLOCK}
-      }
-    }
-  }
-}
-EOF
-    echo "Claude Desktop config created."
+    echo "warning: python3 not found — install Python 3 and re-run to configure Claude Desktop" >&2
   fi
-  echo "Restart Claude Desktop to apply changes."
 fi
 
 # --- Print next steps if keys were not provided ---
@@ -147,8 +136,8 @@ if [ -z "$LUNO_API_KEY_ID" ] || [ -z "$LUNO_API_SECRET" ]; then
   echo ""
   echo "To configure Claude Desktop, re-run with your Luno API credentials:"
   echo ""
-  echo "  LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> \\"
-  echo "    curl -fsSL https://raw.githubusercontent.com/${REPO}/main/claude-desktop-install.sh | sh"
+  echo "  curl -fsSL https://raw.githubusercontent.com/${REPO}/main/claude-desktop-install.sh | \\"
+  echo "    LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> sh"
   echo ""
   echo "Get API keys from: https://www.luno.com/wallet/security/api"
 fi

--- a/claude-desktop-install.sh
+++ b/claude-desktop-install.sh
@@ -48,9 +48,11 @@ trap 'rm -rf "$TMP"' EXIT
 curl -fsSL "${BASE_URL}/${TARBALL}"      -o "${TMP}/${TARBALL}"
 curl -fsSL "${BASE_URL}/checksums.txt"   -o "${TMP}/checksums.txt"
 
-# Verify checksum using whichever tool is available
+# Verify checksum — macOS ships BSD sha256sum which lacks -c; use shasum there
 cd "$TMP"
-if command -v sha256sum >/dev/null 2>&1; then
+if [ "$OS" = "darwin" ] && command -v shasum >/dev/null 2>&1; then
+  grep "${TARBALL}" checksums.txt | shasum -a 256 -c --quiet
+elif command -v sha256sum >/dev/null 2>&1; then
   grep "${TARBALL}" checksums.txt | sha256sum -c --quiet
 elif command -v shasum >/dev/null 2>&1; then
   grep "${TARBALL}" checksums.txt | shasum -a 256 -c --quiet
@@ -91,13 +93,18 @@ import json, os
 p = os.path.expanduser("$CLAUDE_DESKTOP_CONFIG")
 with open(p) as f:
     c = json.load(f)
+env = {
+    "LUNO_API_KEY_ID": "$LUNO_API_KEY_ID",
+    "LUNO_API_SECRET": "$LUNO_API_SECRET"
+}
+if "$LUNO_API_DOMAIN":
+    env["LUNO_API_DOMAIN"] = "$LUNO_API_DOMAIN"
+if "$ALLOW_WRITE_OPERATIONS":
+    env["ALLOW_WRITE_OPERATIONS"] = "$ALLOW_WRITE_OPERATIONS"
 c.setdefault("mcpServers", {})["luno"] = {
     "command": "$BINARY",
     "args": ["--transport", "stdio"],
-    "env": {
-        "LUNO_API_KEY_ID": "$LUNO_API_KEY_ID",
-        "LUNO_API_SECRET": "$LUNO_API_SECRET"
-    }
+    "env": env
 }
 with open(p, "w") as f:
     json.dump(c, f, indent=2)
@@ -109,6 +116,13 @@ PYEOF
     fi
   else
     mkdir -p "$(dirname "$CLAUDE_DESKTOP_CONFIG")"
+    # Build env block, adding optional vars only when set
+    ENV_BLOCK="        \"LUNO_API_KEY_ID\": \"${LUNO_API_KEY_ID}\",
+        \"LUNO_API_SECRET\": \"${LUNO_API_SECRET}\""
+    [ -n "$LUNO_API_DOMAIN" ]         && ENV_BLOCK="${ENV_BLOCK},
+        \"LUNO_API_DOMAIN\": \"${LUNO_API_DOMAIN}\""
+    [ -n "$ALLOW_WRITE_OPERATIONS" ]  && ENV_BLOCK="${ENV_BLOCK},
+        \"ALLOW_WRITE_OPERATIONS\": \"${ALLOW_WRITE_OPERATIONS}\""
     cat > "$CLAUDE_DESKTOP_CONFIG" <<EOF
 {
   "mcpServers": {
@@ -116,8 +130,7 @@ PYEOF
       "command": "${BINARY}",
       "args": ["--transport", "stdio"],
       "env": {
-        "LUNO_API_KEY_ID": "${LUNO_API_KEY_ID}",
-        "LUNO_API_SECRET": "${LUNO_API_SECRET}"
+${ENV_BLOCK}
       }
     }
   }
@@ -135,7 +148,7 @@ if [ -z "$LUNO_API_KEY_ID" ] || [ -z "$LUNO_API_SECRET" ]; then
   echo "To configure Claude Desktop, re-run with your Luno API credentials:"
   echo ""
   echo "  LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> \\"
-  echo "    curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | sh"
+  echo "    curl -fsSL https://raw.githubusercontent.com/${REPO}/main/claude-desktop-install.sh | sh"
   echo ""
   echo "Get API keys from: https://www.luno.com/wallet/security/api"
 fi

--- a/claude-desktop-install.sh
+++ b/claude-desktop-install.sh
@@ -25,7 +25,7 @@ esac
 # --- Resolve version ---
 
 if [ -z "$VERSION" ]; then
-  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+  VERSION="$(curl --proto '=https' --tlsv1.2 -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
     | grep '"tag_name"' \
     | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
   if [ -z "$VERSION" ]; then
@@ -45,8 +45,8 @@ echo "Installing ${BINARY} v${VERSION} (${OS}/${ARCH})..."
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-curl -fsSL "${BASE_URL}/${TARBALL}"      -o "${TMP}/${TARBALL}"
-curl -fsSL "${BASE_URL}/checksums.txt"   -o "${TMP}/checksums.txt"
+curl --proto '=https' --tlsv1.2 -fsSL "${BASE_URL}/${TARBALL}"    -o "${TMP}/${TARBALL}"
+curl --proto '=https' --tlsv1.2 -fsSL "${BASE_URL}/checksums.txt" -o "${TMP}/checksums.txt"
 
 # Verify checksum — macOS ships BSD sha256sum which lacks -c; use shasum there
 cd "$TMP"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env sh
+set -e
+
+REPO="luno/luno-mcp"
+BINARY="luno-mcp"
+DEFAULT_INSTALL_DIR="/usr/local/bin"
+CLAUDE_DESKTOP_CONFIG="${HOME}/Library/Application Support/Claude/claude_desktop_config.json"
+
+# --- Detect platform ---
+
+OS="$(uname -s)"
+case "$OS" in
+  Darwin) OS="darwin" ;;
+  Linux)  OS="linux" ;;
+  *)      echo "Unsupported OS: $OS" >&2; exit 1 ;;
+esac
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)          ARCH="amd64" ;;
+  aarch64 | arm64) ARCH="arm64" ;;
+  *)               echo "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+# --- Resolve version ---
+
+if [ -z "$VERSION" ]; then
+  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' \
+    | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
+  if [ -z "$VERSION" ]; then
+    echo "error: could not determine latest version" >&2
+    exit 1
+  fi
+fi
+VERSION="${VERSION#v}"
+
+# --- Download and verify ---
+
+TARBALL="${BINARY}-${OS}-${ARCH}.tar.gz"
+BASE_URL="https://github.com/${REPO}/releases/download/v${VERSION}"
+
+echo "Installing ${BINARY} v${VERSION} (${OS}/${ARCH})..."
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+curl -fsSL "${BASE_URL}/${TARBALL}"      -o "${TMP}/${TARBALL}"
+curl -fsSL "${BASE_URL}/checksums.txt"   -o "${TMP}/checksums.txt"
+
+# Verify checksum using whichever tool is available
+cd "$TMP"
+if command -v sha256sum >/dev/null 2>&1; then
+  grep "${TARBALL}" checksums.txt | sha256sum -c --quiet
+elif command -v shasum >/dev/null 2>&1; then
+  grep "${TARBALL}" checksums.txt | shasum -a 256 -c --quiet
+else
+  echo "warning: no sha256 tool found, skipping checksum verification" >&2
+fi
+
+tar xzf "${TARBALL}"
+
+# --- Install binary ---
+
+INSTALL_DIR="$DEFAULT_INSTALL_DIR"
+
+if [ -w "$INSTALL_DIR" ]; then
+  mv "${BINARY}" "${INSTALL_DIR}/${BINARY}"
+elif command -v sudo >/dev/null 2>&1; then
+  echo "Installing to ${INSTALL_DIR} (requires sudo)..."
+  sudo mv "${BINARY}" "${INSTALL_DIR}/${BINARY}"
+  sudo chmod +x "${INSTALL_DIR}/${BINARY}"
+else
+  INSTALL_DIR="${HOME}/.local/bin"
+  mkdir -p "$INSTALL_DIR"
+  mv "${BINARY}" "${INSTALL_DIR}/${BINARY}"
+  echo "note: installed to ${INSTALL_DIR} — add it to your PATH if not already present"
+fi
+chmod +x "${INSTALL_DIR}/${BINARY}" 2>/dev/null || true
+
+echo "${BINARY} v${VERSION} installed to ${INSTALL_DIR}/${BINARY}"
+
+# --- Configure Claude Desktop (macOS only, if API keys are provided) ---
+
+if [ "$OS" = "darwin" ] && [ -n "$LUNO_API_KEY_ID" ] && [ -n "$LUNO_API_SECRET" ]; then
+  if [ -f "$CLAUDE_DESKTOP_CONFIG" ]; then
+    # Merge into existing config using Python if available, otherwise append a warning
+    if command -v python3 >/dev/null 2>&1; then
+      python3 - <<PYEOF
+import json, os
+p = os.path.expanduser("$CLAUDE_DESKTOP_CONFIG")
+with open(p) as f:
+    c = json.load(f)
+c.setdefault("mcpServers", {})["luno"] = {
+    "command": "$BINARY",
+    "args": ["--transport", "stdio"],
+    "env": {
+        "LUNO_API_KEY_ID": "$LUNO_API_KEY_ID",
+        "LUNO_API_SECRET": "$LUNO_API_SECRET"
+    }
+}
+with open(p, "w") as f:
+    json.dump(c, f, indent=2)
+    f.write("\n")
+PYEOF
+      echo "Claude Desktop configured."
+    else
+      echo "warning: python3 not found — Claude Desktop config not updated automatically" >&2
+    fi
+  else
+    mkdir -p "$(dirname "$CLAUDE_DESKTOP_CONFIG")"
+    cat > "$CLAUDE_DESKTOP_CONFIG" <<EOF
+{
+  "mcpServers": {
+    "luno": {
+      "command": "${BINARY}",
+      "args": ["--transport", "stdio"],
+      "env": {
+        "LUNO_API_KEY_ID": "${LUNO_API_KEY_ID}",
+        "LUNO_API_SECRET": "${LUNO_API_SECRET}"
+      }
+    }
+  }
+}
+EOF
+    echo "Claude Desktop config created."
+  fi
+  echo "Restart Claude Desktop to apply changes."
+fi
+
+# --- Print next steps if keys were not provided ---
+
+if [ -z "$LUNO_API_KEY_ID" ] || [ -z "$LUNO_API_SECRET" ]; then
+  echo ""
+  echo "To configure Claude Desktop, re-run with your Luno API credentials:"
+  echo ""
+  echo "  LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> \\"
+  echo "    curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | sh"
+  echo ""
+  echo "Get API keys from: https://www.luno.com/wallet/security/api"
+fi


### PR DESCRIPTION
## What

Adds `claude-desktop-install.sh` — a shell script that installs `luno-mcp` and optionally configures Claude Desktop using only tools available by default on macOS and Linux (curl, shasum/sha256sum, tar).

```sh
# Install binary only
curl -fsSL https://raw.githubusercontent.com/luno/luno-mcp/main/claude-desktop-install.sh | sh

# Install + configure Claude Desktop
LUNO_API_KEY_ID=<key> LUNO_API_SECRET=<secret> \
  curl -fsSL https://raw.githubusercontent.com/luno/luno-mcp/main/claude-desktop-install.sh | sh
```

## Why

Homebrew, Python 3, and jq are not available by default on macOS, making the existing installation options inaccessible to non-engineers. This script requires nothing beyond what ships with the OS.

## Details

- Detects OS + architecture, downloads the matching release tarball, verifies checksum
- Installs to `/usr/local/bin` (sudo if needed) with `~/.local/bin` as fallback
- Merges into existing `claude_desktop_config.json` without overwriting other MCP servers (uses Python if available, otherwise creates fresh)
- Supports optional `LUNO_API_DOMAIN` and `ALLOW_WRITE_OPERATIONS` env vars for staging/write use cases
- Documents the one-liner in the README Claude Desktop section
- Adds a staging variant to CONTRIBUTING.md

_AI Assisted — Claude Sonnet 4.6 via Claude Code_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One‑line macOS installer for Claude Desktop that can auto-configure API credentials and install the CLI.

* **Documentation**
  * Simplified Claude Desktop setup and installer instructions.
  * Updated Homebrew tap references and install guidance.
  * Revised release process docs describing GitHub Release–driven publication flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->