### PR TITLE
fix: Resolve stdio MCP JSON error and improve install script

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -29,3 +29,23 @@ jobs:
 
       - name: Run tests
         run: go test -v ./...
+
+  install-script:
+    name: Install Script Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run install script test
+        run: sh scripts/test-install.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,12 @@ repos:
 
       # Go Test
       - id: go-test-repo-mod
+
+  - repo: local
+    hooks:
+      - id: test-install-script
+        name: Test install script
+        language: system
+        entry: sh scripts/test-install.sh
+        files: ^claude-desktop-install\.sh$
+        pass_filenames: false

--- a/claude-desktop-install.sh
+++ b/claude-desktop-install.sh
@@ -75,7 +75,26 @@ mkdir -p "$INSTALL_DIR"
 mv "${BINARY}" "${INSTALL_DIR}/${BINARY}"
 chmod +x "${INSTALL_DIR}/${BINARY}"
 if [ -n "${INSTALL_FALLBACK:-}" ]; then
-  echo "note: ${DEFAULT_INSTALL_DIR} is not writable; installed to ${INSTALL_DIR} — add it to your PATH if not already present"
+  echo "note: ${DEFAULT_INSTALL_DIR} is not writable; installed to ${INSTALL_DIR}"
+  case "${SHELL:-}" in
+    */zsh)  SHELL_PROFILE="${HOME}/.zshrc" ;;
+    */bash)
+      # macOS bash login shells read .bash_profile; Linux interactive shells read .bashrc
+      if [ "$OS" = "darwin" ]; then
+        SHELL_PROFILE="${HOME}/.bash_profile"
+      else
+        SHELL_PROFILE="${HOME}/.bashrc"
+      fi
+      ;;
+    *)      SHELL_PROFILE="${HOME}/.profile" ;;
+  esac
+  if ! echo ":${PATH}:" | grep -q ":${INSTALL_DIR}:"; then
+    if ! grep -qF "${INSTALL_DIR}" "${SHELL_PROFILE}" 2>/dev/null; then
+      printf '\nexport PATH="%s:$PATH"\n' "${INSTALL_DIR}" >> "${SHELL_PROFILE}"
+      echo "note: added ${INSTALL_DIR} to PATH in ${SHELL_PROFILE}"
+    fi
+    echo "note: run 'source ${SHELL_PROFILE}' or open a new terminal for PATH to take effect"
+  fi
 fi
 
 echo "${BINARY} v${VERSION} installed to ${INSTALL_DIR}/${BINARY}"

--- a/claude-desktop-install.sh
+++ b/claude-desktop-install.sh
@@ -26,10 +26,12 @@ esac
 # --- Resolve version ---
 
 if [ -z "$VERSION" ]; then
-  VERSION="$(curl --proto '=https' --tlsv1.2 -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep '"tag_name"' \
-    | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
-  if [ -z "$VERSION" ]; then
+  # Resolve via the github.com redirect rather than api.github.com - the API rate-limits
+  # unauthenticated callers to 60/hour per IP, the redirect has no such limit.
+  VERSION="$(curl --proto '=https' --tlsv1.2 -fsSLI -o /dev/null -w '%{url_effective}' \
+    "https://github.com/${REPO}/releases/latest" \
+    | sed 's|.*/tag/||')"
+  if [ -z "$VERSION" ] || [ "$VERSION" = "https://github.com/${REPO}/releases/latest" ]; then
     echo "error: could not determine latest version" >&2
     exit 1
   fi

--- a/claude-desktop-install.sh
+++ b/claude-desktop-install.sh
@@ -5,12 +5,13 @@ REPO="luno/luno-mcp"
 BINARY="luno-mcp"
 DEFAULT_INSTALL_DIR="/usr/local/bin"
 CLAUDE_DESKTOP_CONFIG="${HOME}/Library/Application Support/Claude/claude_desktop_config.json"
+readonly OS_DARWIN="darwin"
 
 # --- Detect platform ---
 
 OS="$(uname -s)"
 case "$OS" in
-  Darwin) OS="darwin" ;;
+  Darwin) OS="$OS_DARWIN" ;;
   Linux)  OS="linux" ;;
   *)      echo "Unsupported OS: $OS" >&2; exit 1 ;;
 esac
@@ -50,7 +51,7 @@ curl --proto '=https' --tlsv1.2 -fsSL "${BASE_URL}/checksums.txt" -o "${TMP}/che
 
 # Verify checksum — macOS ships BSD sha256sum which lacks -c; use shasum there
 cd "$TMP"
-if [ "$OS" = "darwin" ] && command -v shasum >/dev/null 2>&1; then
+if [ "$OS" = "$OS_DARWIN" ] && command -v shasum >/dev/null 2>&1; then
   grep "${TARBALL}" checksums.txt | shasum -a 256 -c --quiet
 elif command -v sha256sum >/dev/null 2>&1; then
   grep "${TARBALL}" checksums.txt | sha256sum -c --quiet
@@ -80,7 +81,7 @@ if [ -n "${INSTALL_FALLBACK:-}" ]; then
     */zsh)  SHELL_PROFILE="${HOME}/.zshrc" ;;
     */bash)
       # macOS bash login shells read .bash_profile; Linux interactive shells read .bashrc
-      if [ "$OS" = "darwin" ]; then
+      if [ "$OS" = "$OS_DARWIN" ]; then
         SHELL_PROFILE="${HOME}/.bash_profile"
       else
         SHELL_PROFILE="${HOME}/.bashrc"
@@ -101,7 +102,7 @@ echo "${BINARY} v${VERSION} installed to ${INSTALL_DIR}/${BINARY}"
 
 # --- Configure Claude Desktop (macOS only, if API keys are provided) ---
 
-if [ "$OS" = "darwin" ] && [ -n "$LUNO_API_KEY_ID" ] && [ -n "$LUNO_API_SECRET" ]; then
+if [ "$OS" = "$OS_DARWIN" ] && [ -n "$LUNO_API_KEY_ID" ] && [ -n "$LUNO_API_SECRET" ]; then
   if command -v python3 >/dev/null 2>&1; then
     mkdir -p "$(dirname "$CLAUDE_DESKTOP_CONFIG")"
     CLAUDE_DESKTOP_CONFIG="$CLAUDE_DESKTOP_CONFIG" \

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"log/slog"
 	"os"
@@ -73,19 +74,28 @@ func parseFlags() CliFlags {
 	}
 }
 
+// logWriter returns the appropriate writer for log output. In stdio mode stdout
+// is reserved for JSON-RPC, so logs must go to stderr.
+func logWriter(transportType string) io.Writer {
+	if transportType == "stdio" {
+		return os.Stderr
+	}
+	return os.Stdout
+}
+
 // setupLogger creates and configures the basic console logger
-func setupLogger(logLevel string) *slog.Logger {
+func setupLogger(logLevel string, w io.Writer) *slog.Logger {
 	level := parseLogLevel(logLevel)
-	consoleHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: level})
+	consoleHandler := slog.NewTextHandler(w, &slog.HandlerOptions{Level: level})
 	logger := slog.New(consoleHandler)
 	slog.SetDefault(logger)
 	return logger
 }
 
 // setupEnhancedLogger creates an enhanced logger with MCP notification capability
-func setupEnhancedLogger(mcpServer *mcpserver.MCPServer, logLevel string) {
+func setupEnhancedLogger(mcpServer *mcpserver.MCPServer, logLevel string, w io.Writer) {
 	level := parseLogLevel(logLevel)
-	consoleHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: level})
+	consoleHandler := slog.NewTextHandler(w, &slog.HandlerOptions{Level: level})
 	mcpHandler := logging.NewMCPNotificationHandler(mcpServer, level)
 	multiHandler := logging.NewMultiHandler(consoleHandler, mcpHandler)
 	enhancedLogger := slog.New(multiHandler)
@@ -135,25 +145,20 @@ func main() {
 	// Parse command line flags
 	flags := parseFlags()
 
-	// Set up basic logger first
-	setupLogger(flags.LogLevel)
+	logOut := logWriter(flags.TransportType)
+	setupLogger(flags.LogLevel, logOut)
 
-	// Load configuration
 	cfg, err := config.Load(flags.LunoDomain, appName, appVersion)
 	if err != nil {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}
 
-	// CLI flag takes precedence for enabling write operations
 	if flags.AllowWriteOperations {
 		cfg.AllowWriteOperations = true
 	}
 
-	// Create MCP server with logging hooks
 	mcpServer := createMCPServer(cfg)
-
-	// Now enhance the logger with MCP notification capability
-	setupEnhancedLogger(mcpServer, flags.LogLevel)
+	setupEnhancedLogger(mcpServer, flags.LogLevel, logOut)
 
 	// Setup signal handling for graceful shutdown
 	ctx, cancel := setupSignalHandling()

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -257,6 +257,26 @@ func TestSetupLogger(t *testing.T) {
 	}
 }
 
+func TestLogWriter(t *testing.T) {
+	tests := []struct {
+		name      string
+		transport string
+		expected  *os.File
+	}{
+		{name: "stdio uses stderr", transport: "stdio", expected: os.Stderr},
+		{name: "sse uses stdout", transport: "sse", expected: os.Stdout},
+		{name: "streamable-http uses stdout", transport: "streamable-http", expected: os.Stdout},
+		{name: "unknown transport falls back to stdout", transport: "unknown", expected: os.Stdout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := logWriter(tt.transport)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func TestCreateMCPServer(t *testing.T) {
 	// Mock configuration - we'll need to set environment variables for this test
 	t.Setenv("LUNO_API_KEY_ID", "test_key")

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -247,7 +247,7 @@ func TestSetupLogger(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger := setupLogger(tt.logLevel)
+			logger := setupLogger(tt.logLevel, os.Stderr)
 			assert.NotNil(t, logger)
 
 			// Verify the logger was set as default
@@ -386,7 +386,7 @@ func TestMainFunctionFlow(t *testing.T) {
 	})
 
 	t.Run("setup logger", func(t *testing.T) {
-		logger := setupLogger(testLogLevelInfo)
+		logger := setupLogger(testLogLevelInfo, os.Stderr)
 		assert.NotNil(t, logger)
 	})
 
@@ -464,7 +464,7 @@ func TestSetupEnhancedLogger(t *testing.T) {
 			defer slog.SetDefault(originalLogger)
 
 			// Test setupEnhancedLogger - this function sets the default logger
-			setupEnhancedLogger(mcpServer, tt.logLevel)
+			setupEnhancedLogger(mcpServer, tt.logLevel, os.Stderr)
 
 			// Verify the logger was set as default
 			newLogger := slog.Default()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,7 +48,7 @@ func Load(domainOverride, appName, appVersion string) (*Config, error) {
 	apiKeyID := os.Getenv(strings.TrimSpace(EnvLunoAPIKeyID))
 	apiKeySecret := os.Getenv(strings.TrimSpace(EnvLunoAPIKeySecret))
 
-	slog.Debug("Loaded API credentials", "key_id", maskValue(apiKeyID), "key_id_len", len(apiKeyID), "secret_len", len(apiKeySecret))
+	slog.Debug("Loaded API credentials", "api_key_present", apiKeyID != "", "api_secret_present", apiKeySecret != "")
 
 	lunoClient := luno.NewClient()
 	trimmedAppName := strings.TrimSpace(appName)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -47,8 +48,7 @@ func Load(domainOverride, appName, appVersion string) (*Config, error) {
 	apiKeyID := os.Getenv(strings.TrimSpace(EnvLunoAPIKeyID))
 	apiKeySecret := os.Getenv(strings.TrimSpace(EnvLunoAPIKeySecret))
 
-	fmt.Printf("LUNO_API_KEY_ID value: %s (length: %d)\n", maskValue(apiKeyID), len(apiKeyID))
-	fmt.Printf("LUNO_API_SECRET value: %s (length: %d)\n", maskValue(apiKeySecret), len(apiKeySecret))
+	slog.Debug("Loaded API credentials", "key_id", maskValue(apiKeyID), "key_id_len", len(apiKeyID), "secret_len", len(apiKeySecret))
 
 	lunoClient := luno.NewClient()
 	trimmedAppName := strings.TrimSpace(appName)
@@ -61,47 +61,41 @@ func Load(domainOverride, appName, appVersion string) (*Config, error) {
 		LunoClient: lunoClient,
 	}
 
-	// Set domain - first check command line override, then env var, then default
 	domain := DefaultLunoDomain
 
-	// Check for environment variable override
 	if envDomain := os.Getenv(strings.TrimSpace(EnvLunoAPIDomain)); envDomain != "" {
 		domain = envDomain
-		fmt.Printf("Using domain from environment variable: %s\n", domain)
+		slog.Debug("Using domain from environment variable", "domain", domain)
 	}
 
-	// Command line override takes precedence if provided
 	if domainOverride != "" {
 		domain = domainOverride
-		fmt.Printf("Using domain from command line: %s\n", domain)
+		slog.Debug("Using domain from command line flag", "domain", domain)
 	}
 
 	if domain != DefaultLunoDomain {
 		cfg.LunoClient.SetBaseURL(fmt.Sprintf("https://%s", domain))
 	}
 
-	// Only set authentication if both API Key ID and Secret are provided
 	if apiKeyID != "" && apiKeySecret != "" {
 		err := cfg.LunoClient.SetAuth(apiKeyID, apiKeySecret)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set Luno API credentials: %w", err)
 		}
 		cfg.IsAuthenticated = true
-		fmt.Println("Luno client authenticated with provided API credentials.")
+		slog.Info("Luno client authenticated with provided API credentials")
 	} else {
 		cfg.IsAuthenticated = false
-		fmt.Println("Luno API credentials not found. Operating in unauthenticated mode.")
+		slog.Info("Luno API credentials not found, operating in unauthenticated mode")
 	}
 
 	debugMode := parseBoolEnv(EnvLunoAPIDebug)
-	if debugMode {
-		fmt.Println("Debug mode enabled via environment variable")
-	}
+	slog.Debug("Debug mode", "enabled", debugMode)
 	cfg.LunoClient.SetDebug(debugMode)
 
 	allowWriteOps := parseBoolEnv(EnvAllowWriteOperations)
 	if allowWriteOps {
-		fmt.Println("Write operations enabled via environment variable")
+		slog.Info("Write operations enabled via environment variable")
 	}
 	cfg.AllowWriteOperations = allowWriteOps
 	return cfg, nil

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env sh
+# Integration test for claude-desktop-install.sh.
+# Builds the binary, creates a fake release archive, runs the install script
+# with a stub curl, verifies the result, then cleans up everything it touched.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALL_SCRIPT="$REPO_ROOT/claude-desktop-install.sh"
+
+# --- Build ---
+
+echo "==> Building binary..."
+make -C "$REPO_ROOT" build
+
+# --- Platform detection (must match install script logic) ---
+
+OS="$(uname -s)"
+case "$OS" in
+  Darwin) OS="darwin" ;;
+  Linux)  OS="linux" ;;
+  *) echo "Unsupported OS: $OS" >&2; exit 1 ;;
+esac
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64)          ARCH="amd64" ;;
+  aarch64 | arm64) ARCH="arm64" ;;
+  *) echo "Unsupported arch: $ARCH" >&2; exit 1 ;;
+esac
+
+BINARY="luno-mcp"
+TARBALL="${BINARY}-${OS}-${ARCH}.tar.gz"
+
+# --- Temp dirs ---
+
+TMP_RELEASE="$(mktemp -d)"
+TMP_HOME="$(mktemp -d)"
+TMP_BIN="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_RELEASE" "$TMP_HOME" "$TMP_BIN"
+}
+trap cleanup EXIT
+
+# --- Fake release ---
+
+echo "==> Creating fake release archive..."
+cp "$REPO_ROOT/$BINARY" "$TMP_RELEASE/$BINARY"
+(cd "$TMP_RELEASE" && tar czf "$TARBALL" "$BINARY" && rm "$BINARY")
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd "$TMP_RELEASE" && sha256sum "$TARBALL" > checksums.txt)
+elif command -v shasum >/dev/null 2>&1; then
+  (cd "$TMP_RELEASE" && shasum -a 256 "$TARBALL" > checksums.txt)
+else
+  echo "error: no sha256 tool found" >&2; exit 1
+fi
+
+# --- Stub curl ---
+# Parses -o OUTPUT and https://... URL from the argument list, then serves
+# the matching file from TMP_RELEASE instead of hitting GitHub.
+
+cat > "$TMP_BIN/curl" << STUB
+#!/bin/sh
+prev=""
+url=""
+output=""
+for arg; do
+  case "\$prev" in
+    -o) output="\$arg" ;;
+  esac
+  case "\$arg" in
+    https://*) url="\$arg" ;;
+  esac
+  prev="\$arg"
+done
+filename="\$(basename "\$url")"
+src="${TMP_RELEASE}/\$filename"
+if [ ! -f "\$src" ]; then
+  echo "stub curl: file not found: \$src" >&2
+  exit 1
+fi
+cp "\$src" "\$output"
+STUB
+chmod +x "$TMP_BIN/curl"
+
+# --- Run ---
+
+echo "==> Running install script..."
+PATH="$TMP_BIN:$PATH" \
+HOME="$TMP_HOME" \
+SHELL="/bin/sh" \
+VERSION="0.0.0-test" \
+  sh "$INSTALL_SCRIPT"
+
+# --- Verify ---
+
+INSTALL_PATH="$TMP_HOME/.local/bin/$BINARY"
+if [ ! -x "$INSTALL_PATH" ]; then
+  echo "FAIL: binary not installed at $INSTALL_PATH" >&2
+  exit 1
+fi
+echo "PASS: binary installed at $INSTALL_PATH"
+
+PROFILE="$TMP_HOME/.profile"
+if ! grep -qF ".local/bin" "$PROFILE" 2>/dev/null; then
+  echo "FAIL: PATH not added to $PROFILE" >&2
+  exit 1
+fi
+echo "PASS: PATH updated in $PROFILE"
+
+# --- Cleanup handled by trap ---
+
+echo "==> All checks passed."

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -33,14 +33,32 @@ esac
 BINARY="luno-mcp"
 TARBALL="${BINARY}-${OS}-${ARCH}.tar.gz"
 
+# --- Expected install location (mirrors installer logic) ---
+# On CI runners /usr/local/bin is often writable, so the installer goes there
+# instead of falling back to ~/.local/bin. Detect this upfront so verification
+# and cleanup both agree on where the binary should land.
+
+if [ -w "/usr/local/bin" ]; then
+  EXPECTED_INSTALL_PATH="/usr/local/bin/$BINARY"
+  USED_FALLBACK=false
+else
+  USED_FALLBACK=true
+fi
+
 # --- Temp dirs ---
 
 TMP_RELEASE="$(mktemp -d)"
 TMP_HOME="$(mktemp -d)"
 TMP_BIN="$(mktemp -d)"
 
+if [ "$USED_FALLBACK" = "true" ]; then
+  EXPECTED_INSTALL_PATH="$TMP_HOME/.local/bin/$BINARY"
+fi
+
 cleanup() {
   rm -rf "$TMP_RELEASE" "$TMP_HOME" "$TMP_BIN"
+  # Remove system binary if the installer wrote it there (common on CI runners)
+  [ "$USED_FALLBACK" = "false" ] && rm -f "/usr/local/bin/$BINARY" || true
 }
 trap cleanup EXIT
 
@@ -96,19 +114,20 @@ VERSION="0.0.0-test" \
 
 # --- Verify ---
 
-INSTALL_PATH="$TMP_HOME/.local/bin/$BINARY"
-if [ ! -x "$INSTALL_PATH" ]; then
-  echo "FAIL: binary not installed at $INSTALL_PATH" >&2
+if [ ! -x "$EXPECTED_INSTALL_PATH" ]; then
+  echo "FAIL: binary not installed at $EXPECTED_INSTALL_PATH" >&2
   exit 1
 fi
-echo "PASS: binary installed at $INSTALL_PATH"
+echo "PASS: binary installed at $EXPECTED_INSTALL_PATH"
 
-PROFILE="$TMP_HOME/.profile"
-if ! grep -qF ".local/bin" "$PROFILE" 2>/dev/null; then
-  echo "FAIL: PATH not added to $PROFILE" >&2
-  exit 1
+if [ "$USED_FALLBACK" = "true" ]; then
+  PROFILE="$TMP_HOME/.profile"
+  if ! grep -qF ".local/bin" "$PROFILE" 2>/dev/null; then
+    echo "FAIL: PATH not added to $PROFILE" >&2
+    exit 1
+  fi
+  echo "PASS: PATH updated in $PROFILE"
 fi
-echo "PASS: PATH updated in $PROFILE"
 
 # --- Cleanup handled by trap ---
 


### PR DESCRIPTION
## Summary

- **Fix Claude Desktop MCP JSON error**: `fmt.Print*` calls in `config.go` and the `slog` text handler in `main.go` were writing to stdout, corrupting the JSON-RPC stream in stdio transport mode. All log output now routes to stderr when `--transport stdio` is used.
- **Auto-configure PATH**: The install script now appends `~/.local/bin` to the user's shell profile when falling back to a user-local install, with correct profile selection per shell and OS (`zsh` → `.zshrc`, `bash`/macOS → `.bash_profile`, `bash`/Linux → `.bashrc`, fallback → `.profile`).
- **Integration test**: `scripts/test-install.sh` builds the binary, constructs a fake release archive with a stub `curl`, runs the install script end-to-end against a temp `$HOME`, verifies the binary is installed and the shell profile is updated, then cleans everything up.

## Test plan

- [ ] Run `make test` - all Go tests pass
- [ ] Run `sh scripts/test-install.sh` - install test passes and cleans up
- [ ] Restart Claude Desktop after install - no "Unexpected token" MCP error
- [ ] CI `install-script` job passes on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation script now automatically updates shell profile configuration when the default install directory is not writable, eliminating manual PATH configuration steps.

* **Tests**
  * Added integration testing for the installation process to ensure proper fallback directory handling and configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->