### PR TITLE
install: Resolve latest version via redirect to avoid API rate limit

### DIFF
--- a/claude-desktop-install.sh
+++ b/claude-desktop-install.sh
@@ -25,10 +25,12 @@ esac
 # --- Resolve version ---
 
 if [ -z "$VERSION" ]; then
-  VERSION="$(curl --proto '=https' --tlsv1.2 -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep '"tag_name"' \
-    | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
-  if [ -z "$VERSION" ]; then
+  # Resolve via the github.com redirect rather than api.github.com - the API rate-limits
+  # unauthenticated callers to 60/hour per IP, the redirect has no such limit.
+  VERSION="$(curl --proto '=https' --tlsv1.2 -fsSLI -o /dev/null -w '%{url_effective}' \
+    "https://github.com/${REPO}/releases/latest" \
+    | sed 's|.*/tag/||')"
+  if [ -z "$VERSION" ] || [ "$VERSION" = "https://github.com/${REPO}/releases/latest" ]; then
     echo "error: could not determine latest version" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
- Replace `api.github.com/repos/.../releases/latest` lookup in `claude-desktop-install.sh` with a `curl -I` against `github.com/.../releases/latest`, extracting the tag from the redirect's `url_effective`.
- The unauthenticated GitHub API rate-limits to 60/hour per IP, which can break installs on shared NATs/CI. The HTML redirect endpoint has no such limit.
- Adds a guard so a missing redirect (`url_effective` still pointing at `/releases/latest`) is treated as a failure rather than a successful empty version.

## Test plan
- [ ] Run `./claude-desktop-install.sh` with no `VERSION` set and confirm it resolves the latest tag and installs successfully.
- [ ] Run with `VERSION=vX.Y.Z` and confirm the override path still works (unchanged).
- [ ] Simulate a redirect failure (e.g. point `REPO` at a non-existent repo) and confirm the script exits with `error: could not determine latest version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the installation script's version resolution process with improved error handling to ensure more reliable version detection during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->