### PR TITLE
tools: Add Convert tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ docker run --rm \
 Optional environment variables:
 - `LUNO_API_DEBUG=true` — Enable debug logging
 - `LUNO_API_DOMAIN=api.staging.luno.com` — Override API domain
-- `ALLOW_WRITE_OPERATIONS=true` — Enable write operations (`create_order`, `cancel_order`)
+- `ALLOW_WRITE_OPERATIONS=true` — Enable write operations (`create_order`, `cancel_order`, `convert`)
 
 </details>
 
@@ -418,7 +418,7 @@ docker run --rm \
 Optional environment variables:
 - `LUNO_API_DEBUG=true` — Enable debug logging
 - `LUNO_API_DOMAIN=api.staging.luno.com` — Override API domain
-- `ALLOW_WRITE_OPERATIONS=true` — Enable write operations (`create_order`, `cancel_order`)
+- `ALLOW_WRITE_OPERATIONS=true` — Enable write operations (`create_order`, `cancel_order`, `convert`)
 
 </details>
 
@@ -445,6 +445,7 @@ Optional environment variables:
 | `list_orders`       | Trading             | List open orders                                  | ✅            | ❌    |
 | `list_transactions` | Transactions        | List transactions for an account                  | ✅            | ❌    |
 | `get_transaction`   | Transactions        | Get details of a specific transaction             | ✅            | ❌    |
+| `convert`           | Trading             | Instantly convert between two currencies          | ✅            | ✅    |
 
 ## Command-line options
 
@@ -452,7 +453,7 @@ Optional environment variables:
 - `--sse-address`: Address for SSE and Streamable HTTP transports (default: `localhost:8080`)
 - `--domain`: Luno API domain (default: `api.luno.com`)
 - `--log-level`: Log level (`debug`, `info`, `warn`, `error`, default: `info`)
-- `--allow-write-operations`: Enable write operations (`create_order`, `cancel_order`). Also configurable via `ALLOW_WRITE_OPERATIONS` env var
+- `--allow-write-operations`: Enable write operations (`create_order`, `cancel_order`, `convert`). Also configurable via `ALLOW_WRITE_OPERATIONS` env var
 
 ## Examples
 
@@ -498,7 +499,7 @@ This tool requires API credentials that have access to your Luno account. Be cau
 
 ### Write Operations Control
 
-By default, the MCP server runs in **read-only mode** — `create_order` and `cancel_order` are not exposed. To enable them, set `ALLOW_WRITE_OPERATIONS` to `true`, `1`, or `yes`. See the config examples above for where to add this flag.
+By default, the MCP server runs in **read-only mode** — `create_order`, `cancel_order`, and `convert` are not exposed. To enable them, set `ALLOW_WRITE_OPERATIONS` to `true`, `1`, or `yes`. See the config examples above for where to add this flag.
 
 ### Best Practices for API Credentials
 

--- a/go.mod
+++ b/go.mod
@@ -58,5 +58,3 @@ require (
 	golang.org/x/tools v0.42.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/luno/luno-go => github.com/allank/luno-go v0.0.0-20260513172933-770fd8973eae

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 tool github.com/vektra/mockery/v3
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/luno/luno-go v0.2.0
 	github.com/mark3labs/mcp-go v0.52.0
@@ -19,7 +20,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jedib0t/go-pretty/v6 v6.7.8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -59,4 +59,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/luno/luno-go => ../luno-go
+replace github.com/luno/luno-go => github.com/allank/luno-go v0.0.0-20260513172933-770fd8973eae

--- a/go.mod
+++ b/go.mod
@@ -58,3 +58,5 @@ require (
 	golang.org/x/tools v0.42.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/luno/luno-go => ../luno-go

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/allank/luno-go v0.0.0-20260513172933-770fd8973eae h1:omj4LmwuGF0agfKIocT7e4YsXHLVMyeyb1aq+IcedwM=
-github.com/allank/luno-go v0.0.0-20260513172933-770fd8973eae/go.mod h1:czQPrlH+el3/hT9eDKQDBD8uqR0XSXex9n1VjsBa6O4=
 github.com/brunoga/deep v1.3.1 h1:bSrL6FhAZa6JlVv4vsi7Hg8SLwroDb1kgDERRVipBCo=
 github.com/brunoga/deep v1.3.1/go.mod h1:GDV6dnXqn80ezsLSZ5Wlv1PdKAWAO4L5PnKYtv2dgaI=
 github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/allank/luno-go v0.0.0-20260513172933-770fd8973eae h1:omj4LmwuGF0agfKIocT7e4YsXHLVMyeyb1aq+IcedwM=
+github.com/allank/luno-go v0.0.0-20260513172933-770fd8973eae/go.mod h1:czQPrlH+el3/hT9eDKQDBD8uqR0XSXex9n1VjsBa6O4=
 github.com/brunoga/deep v1.3.1 h1:bSrL6FhAZa6JlVv4vsi7Hg8SLwroDb1kgDERRVipBCo=
 github.com/brunoga/deep v1.3.1/go.mod h1:GDV6dnXqn80ezsLSZ5Wlv1PdKAWAO4L5PnKYtv2dgaI=
 github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,15 +78,18 @@ func registerTools(server *mcpserver.MCPServer, cfg *config.Config) {
 	// When disabled, their handlers return an informative error explaining how to enable them.
 	createOrderTool := tools.NewCreateOrderTool()
 	cancelOrderTool := tools.NewCancelOrderTool()
+	convertTool := tools.NewConvertTool()
 
 	if cfg.AllowWriteOperations {
-		slog.Info("Write operations enabled - registering create_order and cancel_order tools")
+		slog.Info("Write operations enabled - registering create_order, cancel_order and convert tools")
 		server.AddTool(createOrderTool, tools.HandleCreateOrder(cfg))
 		server.AddTool(cancelOrderTool, tools.HandleCancelOrder(cfg))
+		server.AddTool(convertTool, tools.HandleConvert(cfg))
 	} else {
-		slog.Info("Write operations disabled - create_order and cancel_order tools registered as disabled")
+		slog.Info("Write operations disabled - create_order, cancel_order and convert tools registered as disabled")
 		server.AddTool(createOrderTool, tools.HandleWriteOperationDisabled())
 		server.AddTool(cancelOrderTool, tools.HandleWriteOperationDisabled())
+		server.AddTool(convertTool, tools.HandleWriteOperationDisabled())
 	}
 
 	listOrdersTool := tools.NewListOrdersTool()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -38,7 +38,7 @@ func TestNewMCPServer(t *testing.T) {
 			version:           testVersion1,
 			hooks:             nil,
 			allowWriteOps:     false,
-			expectedToolCount: 12,
+			expectedToolCount: 13,
 		},
 		{
 			name:              "creates server with write ops enabled",
@@ -46,14 +46,14 @@ func TestNewMCPServer(t *testing.T) {
 			version:           testVersion1,
 			hooks:             nil,
 			allowWriteOps:     true,
-			expectedToolCount: 12,
+			expectedToolCount: 13,
 		},
 		{
 			name:              "creates server with single hook",
 			srvName:           testServerWithHooks,
 			version:           testVersion2,
 			allowWriteOps:     false,
-			expectedToolCount: 12,
+			expectedToolCount: 13,
 			hooks: []*mcpserver.Hooks{
 				func() *mcpserver.Hooks {
 					h := &mcpserver.Hooks{}
@@ -69,7 +69,7 @@ func TestNewMCPServer(t *testing.T) {
 			srvName:           testServerMultiHooks,
 			version:           testVersion3,
 			allowWriteOps:     false,
-			expectedToolCount: 12,
+			expectedToolCount: 13,
 			hooks: []*mcpserver.Hooks{
 				func() *mcpserver.Hooks { // Corresponds to original OnAnyHookFunc
 					h := &mcpserver.Hooks{}
@@ -151,10 +151,12 @@ func TestWriteOperationsControl(t *testing.T) {
 				"%s: expected %s tool to always be registered", tc.name, tools.CreateOrderToolID)
 			require.Contains(t, registeredTools, tools.CancelOrderToolID,
 				"%s: expected %s tool to always be registered", tc.name, tools.CancelOrderToolID)
+			require.Contains(t, registeredTools, tools.ConvertToolID,
+				"%s: expected %s tool to always be registered", tc.name, tools.ConvertToolID)
 
 			// When disabled, verify the server routes calls to the disabled handler
 			if !tc.allowWriteOps {
-				for _, toolID := range []string{tools.CreateOrderToolID, tools.CancelOrderToolID} {
+				for _, toolID := range []string{tools.CreateOrderToolID, tools.CancelOrderToolID, tools.ConvertToolID} {
 					resp := callTool(t, srv, toolID)
 					require.Contains(t, resp, tools.ErrWriteOperationDisabled,
 						"%s: calling %s should return disabled error", tc.name, toolID)

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/luno/luno-go"
 	"github.com/luno/luno-go/decimal"
 	"github.com/luno/luno-mcp/internal/config"
@@ -40,6 +41,7 @@ const (
 	ListTradesToolID       = "list_trades"
 	GetCandlesToolID       = "get_candles"
 	GetMarketsInfoToolID   = "get_markets_info"
+	ConvertToolID          = "convert"
 )
 
 // ===== Balance Tools =====
@@ -490,6 +492,91 @@ func HandleCancelOrder(cfg *config.Config) server.ToolHandlerFunc {
 		})
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to cancel order: %v", err)), nil
+		}
+
+		resultJSON, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal result: %v", err)), nil
+		}
+
+		return mcp.NewToolResultText(string(resultJSON)), nil
+	}
+}
+
+// NewConvertTool creates a new tool for converting between currencies
+func NewConvertTool() mcp.Tool {
+	return mcp.NewTool(
+		ConvertToolID,
+		mcp.WithDescription("Instantly convert between two currencies (e.g. ZAR to ZARU) using the Luno broker."+writeOperationNotice),
+		mcp.WithString(
+			"source_account_id",
+			mcp.Required(),
+			mcp.Description("Account ID to convert funds from"),
+		),
+		mcp.WithString(
+			"target_account_id",
+			mcp.Required(),
+			mcp.Description("Account ID to receive converted funds"),
+		),
+		mcp.WithString(
+			"amount",
+			mcp.Required(),
+			mcp.Description("Decimal amount to convert (e.g. \"100.00\")"),
+		),
+		mcp.WithString(
+			"idempotency_key",
+			mcp.Description("Unique key to prevent duplicate conversions; auto-generated UUID if omitted"),
+		),
+	)
+}
+
+// HandleConvert handles the convert tool
+func HandleConvert(cfg *config.Config) server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if !cfg.IsAuthenticated {
+			return mcp.NewToolResultError(ErrAPICredentialsRequired), nil
+		}
+
+		sourceAccountIDStr, err := request.RequireString("source_account_id")
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("getting source_account_id from request", err), nil
+		}
+		sourceAccountID, err := strconv.ParseInt(sourceAccountIDStr, 10, 64)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Invalid source account ID format: %v", err)), nil
+		}
+
+		targetAccountIDStr, err := request.RequireString("target_account_id")
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("getting target_account_id from request", err), nil
+		}
+		targetAccountID, err := strconv.ParseInt(targetAccountIDStr, 10, 64)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Invalid target account ID format: %v", err)), nil
+		}
+
+		amountStr, err := request.RequireString("amount")
+		if err != nil {
+			return mcp.NewToolResultErrorFromErr("getting amount from request", err), nil
+		}
+		amount, err := decimal.NewFromString(amountStr)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Invalid amount format: %v", err)), nil
+		}
+
+		idempotencyKey := request.GetString("idempotency_key", "")
+		if idempotencyKey == "" {
+			idempotencyKey = uuid.New().String()
+		}
+
+		result, err := cfg.LunoClient.Convert(ctx, &luno.ConvertRequest{
+			SourceAccountId: sourceAccountID,
+			TargetAccountId: targetAccountID,
+			Amount:          amount,
+			IdempotencyKey:  idempotencyKey,
+		})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to convert: %v", err)), nil
 		}
 
 		resultJSON, err := json.MarshalIndent(result, "", "  ")

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -545,6 +545,9 @@ func HandleConvert(cfg *config.Config) server.ToolHandlerFunc {
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Invalid source account ID format: %v", err)), nil
 		}
+		if sourceAccountID <= 0 {
+			return mcp.NewToolResultError("Invalid source account ID: must be a positive integer"), nil
+		}
 
 		targetAccountIDStr, err := request.RequireString("target_account_id")
 		if err != nil {
@@ -553,6 +556,9 @@ func HandleConvert(cfg *config.Config) server.ToolHandlerFunc {
 		targetAccountID, err := strconv.ParseInt(targetAccountIDStr, 10, 64)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Invalid target account ID format: %v", err)), nil
+		}
+		if targetAccountID <= 0 {
+			return mcp.NewToolResultError("Invalid target account ID: must be a positive integer"), nil
 		}
 
 		amountStr, err := request.RequireString("amount")

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -563,6 +563,9 @@ func HandleConvert(cfg *config.Config) server.ToolHandlerFunc {
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Invalid amount format: %v", err)), nil
 		}
+		if amount.Sign() <= 0 {
+			return mcp.NewToolResultError("amount must be positive"), nil
+		}
 
 		idempotencyKey := request.GetString("idempotency_key", "")
 		if idempotencyKey == "" {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -566,7 +566,11 @@ func HandleConvert(cfg *config.Config) server.ToolHandlerFunc {
 
 		idempotencyKey := request.GetString("idempotency_key", "")
 		if idempotencyKey == "" {
-			idempotencyKey = uuid.New().String()
+			uid, err := uuid.NewRandom()
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Failed to generate idempotency key: %v", err)), nil
+			}
+			idempotencyKey = uid.String()
 		}
 
 		result, err := cfg.LunoClient.Convert(ctx, &luno.ConvertRequest{

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1658,6 +1658,54 @@ func TestHandleConvert(t *testing.T) {
 			errorContains:   "Invalid amount",
 		},
 		{
+			name: "zero source account ID",
+			requestParams: map[string]any{
+				"source_account_id": "0",
+				"target_account_id": "456",
+				"amount":            "100.00",
+			},
+			mockSetup:       func(t *testing.T, mockClient *sdk.MockLunoClient) {},
+			isAuthenticated: true,
+			expectedError:   true,
+			errorContains:   "Invalid source account ID: must be a positive integer",
+		},
+		{
+			name: "negative source account ID",
+			requestParams: map[string]any{
+				"source_account_id": "-1",
+				"target_account_id": "456",
+				"amount":            "100.00",
+			},
+			mockSetup:       func(t *testing.T, mockClient *sdk.MockLunoClient) {},
+			isAuthenticated: true,
+			expectedError:   true,
+			errorContains:   "Invalid source account ID: must be a positive integer",
+		},
+		{
+			name: "zero target account ID",
+			requestParams: map[string]any{
+				"source_account_id": "123",
+				"target_account_id": "0",
+				"amount":            "100.00",
+			},
+			mockSetup:       func(t *testing.T, mockClient *sdk.MockLunoClient) {},
+			isAuthenticated: true,
+			expectedError:   true,
+			errorContains:   "Invalid target account ID: must be a positive integer",
+		},
+		{
+			name: "negative target account ID",
+			requestParams: map[string]any{
+				"source_account_id": "123",
+				"target_account_id": "-1",
+				"amount":            "100.00",
+			},
+			mockSetup:       func(t *testing.T, mockClient *sdk.MockLunoClient) {},
+			isAuthenticated: true,
+			expectedError:   true,
+			errorContains:   "Invalid target account ID: must be a positive integer",
+		},
+		{
 			name: "zero amount",
 			requestParams: map[string]any{
 				"source_account_id": "123",
@@ -1735,9 +1783,11 @@ func TestHandleConvert(t *testing.T) {
 				"amount":            "100.00",
 			},
 			mockSetup: func(t *testing.T, mockClient *sdk.MockLunoClient) {
+				expectedAmount := NewFromString(t, "100.00")
 				mockClient.EXPECT().Convert(context.Background(), mock.MatchedBy(func(req *luno.ConvertRequest) bool {
 					return req.SourceAccountId == 123 &&
 						req.TargetAccountId == 456 &&
+						req.Amount.Cmp(expectedAmount) == 0 &&
 						req.IdempotencyKey != ""
 				})).Return(&luno.ConvertResponse{
 					Id:                   "conv-002",

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1658,6 +1658,30 @@ func TestHandleConvert(t *testing.T) {
 			errorContains:   "Invalid amount",
 		},
 		{
+			name: "zero amount",
+			requestParams: map[string]any{
+				"source_account_id": "123",
+				"target_account_id": "456",
+				"amount":            "0",
+			},
+			mockSetup:       func(t *testing.T, mockClient *sdk.MockLunoClient) {},
+			isAuthenticated: true,
+			expectedError:   true,
+			errorContains:   "amount must be positive",
+		},
+		{
+			name: "negative amount",
+			requestParams: map[string]any{
+				"source_account_id": "123",
+				"target_account_id": "456",
+				"amount":            "-50.00",
+			},
+			mockSetup:       func(t *testing.T, mockClient *sdk.MockLunoClient) {},
+			isAuthenticated: true,
+			expectedError:   true,
+			errorContains:   "amount must be positive",
+		},
+		{
 			name: "API error",
 			requestParams: map[string]any{
 				"source_account_id": "123",

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -154,6 +154,12 @@ func TestToolCreation(t *testing.T) {
 			toolName: GetMarketsInfoToolID,
 			params:   []string{"pair"},
 		},
+		{
+			name:     "Convert tool",
+			toolFunc: NewConvertTool,
+			toolName: ConvertToolID,
+			params:   []string{"source_account_id", "target_account_id", "amount", "idempotency_key"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1589,6 +1595,169 @@ func TestHandleGetMarketsInfo(t *testing.T) {
 				}
 			} else {
 				assert.False(t, result.IsError)
+			}
+		})
+	}
+}
+
+func TestHandleConvert(t *testing.T) {
+	tests := []struct {
+		name            string
+		requestParams   map[string]any
+		mockSetup       func(*testing.T, *sdk.MockLunoClient)
+		isAuthenticated bool
+		expectedError   bool
+		errorContains   string
+	}{
+		{
+			name: "unauthenticated",
+			requestParams: map[string]any{
+				"source_account_id": "123",
+				"target_account_id": "456",
+				"amount":            "100.00",
+			},
+			mockSetup:       func(t *testing.T, mockClient *sdk.MockLunoClient) {},
+			isAuthenticated: false,
+			expectedError:   true,
+			errorContains:   ErrAPICredentialsRequired,
+		},
+		{
+			name: "invalid source account ID",
+			requestParams: map[string]any{
+				"source_account_id": "not-a-number",
+				"target_account_id": "456",
+				"amount":            "100.00",
+			},
+			mockSetup:       func(t *testing.T, mockClient *sdk.MockLunoClient) {},
+			isAuthenticated: true,
+			expectedError:   true,
+			errorContains:   "Invalid source account ID",
+		},
+		{
+			name: "invalid target account ID",
+			requestParams: map[string]any{
+				"source_account_id": "123",
+				"target_account_id": "not-a-number",
+				"amount":            "100.00",
+			},
+			mockSetup:       func(t *testing.T, mockClient *sdk.MockLunoClient) {},
+			isAuthenticated: true,
+			expectedError:   true,
+			errorContains:   "Invalid target account ID",
+		},
+		{
+			name: "invalid amount",
+			requestParams: map[string]any{
+				"source_account_id": "123",
+				"target_account_id": "456",
+				"amount":            "not-a-number",
+			},
+			mockSetup:       func(t *testing.T, mockClient *sdk.MockLunoClient) {},
+			isAuthenticated: true,
+			expectedError:   true,
+			errorContains:   "Invalid amount",
+		},
+		{
+			name: "API error",
+			requestParams: map[string]any{
+				"source_account_id": "123",
+				"target_account_id": "456",
+				"amount":            "100.00",
+			},
+			mockSetup: func(t *testing.T, mockClient *sdk.MockLunoClient) {
+				mockClient.EXPECT().Convert(context.Background(), mock.MatchedBy(func(req *luno.ConvertRequest) bool {
+					expectedAmount := NewFromString(t, "100.00")
+					return req.SourceAccountId == 123 &&
+						req.TargetAccountId == 456 &&
+						req.Amount.Cmp(expectedAmount) == 0
+				})).Return(nil, errors.New(apiErrorStr))
+			},
+			isAuthenticated: true,
+			expectedError:   true,
+			errorContains:   "Failed to convert",
+		},
+		{
+			name: "successful convert with explicit idempotency key",
+			requestParams: map[string]any{
+				"source_account_id": "123",
+				"target_account_id": "456",
+				"amount":            "100.00",
+				"idempotency_key":   "my-key-123",
+			},
+			mockSetup: func(t *testing.T, mockClient *sdk.MockLunoClient) {
+				expectedAmount := NewFromString(t, "100.00")
+				mockClient.EXPECT().Convert(context.Background(), mock.MatchedBy(func(req *luno.ConvertRequest) bool {
+					return req.SourceAccountId == 123 &&
+						req.TargetAccountId == 456 &&
+						req.Amount.Cmp(expectedAmount) == 0 &&
+						req.IdempotencyKey == "my-key-123"
+				})).Return(&luno.ConvertResponse{
+					Id:                   "conv-001",
+					ConvertedAmount:      NewFromString(t, "95.00"),
+					SourceCurrency:       "ZAR",
+					TargetCurrency:       "ZARU",
+					SourceAccountBalance: NewFromString(t, "900.00"),
+					TargetAccountBalance: NewFromString(t, "195.00"),
+				}, nil)
+			},
+			isAuthenticated: true,
+			expectedError:   false,
+		},
+		{
+			name: "successful convert with auto-generated idempotency key",
+			requestParams: map[string]any{
+				"source_account_id": "123",
+				"target_account_id": "456",
+				"amount":            "100.00",
+			},
+			mockSetup: func(t *testing.T, mockClient *sdk.MockLunoClient) {
+				mockClient.EXPECT().Convert(context.Background(), mock.MatchedBy(func(req *luno.ConvertRequest) bool {
+					return req.SourceAccountId == 123 &&
+						req.TargetAccountId == 456 &&
+						req.IdempotencyKey != ""
+				})).Return(&luno.ConvertResponse{
+					Id:                   "conv-002",
+					ConvertedAmount:      NewFromString(t, "95.00"),
+					SourceCurrency:       "ZAR",
+					TargetCurrency:       "ZARU",
+					SourceAccountBalance: NewFromString(t, "900.00"),
+					TargetAccountBalance: NewFromString(t, "195.00"),
+				}, nil)
+			},
+			isAuthenticated: true,
+			expectedError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := sdk.NewMockLunoClient(t)
+			tt.mockSetup(t, mockClient)
+
+			cfg := &config.Config{
+				LunoClient:      mockClient,
+				IsAuthenticated: tt.isAuthenticated,
+			}
+
+			handler := HandleConvert(cfg)
+			request := createMockRequest(tt.requestParams)
+
+			result, err := handler(context.Background(), request)
+
+			assert.NoError(t, err)
+			if tt.expectedError {
+				assert.True(t, result.IsError)
+				if tt.errorContains != "" {
+					errorText := getTextContentFromResult(t, result)
+					assert.Contains(t, errorText, tt.errorContains)
+				}
+			} else {
+				assert.False(t, result.IsError)
+				textContent := getTextContentFromResult(t, result)
+				assert.NotEmpty(t, textContent)
+				var response map[string]any
+				assert.NoError(t, json.Unmarshal([]byte(textContent), &response))
+				assert.NotEmpty(t, response["id"])
 			}
 		})
 	}

--- a/sdk/luno_client.go
+++ b/sdk/luno_client.go
@@ -24,6 +24,7 @@ type LunoClient interface {
 	GetTickers(ctx context.Context, req *luno.GetTickersRequest) (*luno.GetTickersResponse, error)
 	GetOrderBookFull(ctx context.Context, req *luno.GetOrderBookFullRequest) (*luno.GetOrderBookFullResponse, error)
 	Markets(ctx context.Context, req *luno.MarketsRequest) (*luno.MarketsResponse, error)
+	Convert(ctx context.Context, req *luno.ConvertRequest) (*luno.ConvertResponse, error)
 	SetBaseURL(url string)
 	SetAuth(id, secret string) error
 	SetDebug(debug bool)

--- a/sdk/mock_luno_client_gen.go
+++ b/sdk/mock_luno_client_gen.go
@@ -967,3 +967,71 @@ func (_c *MockLunoClient_SetDebug_Call) RunAndReturn(run func(bool)) *MockLunoCl
 	_c.Call.Return(run)
 	return _c
 }
+
+// Convert provides a mock function for the type MockLunoClient
+func (_mock *MockLunoClient) Convert(ctx context.Context, req *luno.ConvertRequest) (*luno.ConvertResponse, error) {
+	ret := _mock.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Convert")
+	}
+
+	var r0 *luno.ConvertResponse
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *luno.ConvertRequest) (*luno.ConvertResponse, error)); ok {
+		return returnFunc(ctx, req)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *luno.ConvertRequest) *luno.ConvertResponse); ok {
+		r0 = returnFunc(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*luno.ConvertResponse)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *luno.ConvertRequest) error); ok {
+		r1 = returnFunc(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockLunoClient_Convert_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Convert'
+type MockLunoClient_Convert_Call struct {
+	*mock.Call
+}
+
+// Convert is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *luno.ConvertRequest
+func (_e *MockLunoClient_Expecter) Convert(ctx interface{}, req interface{}) *MockLunoClient_Convert_Call {
+	return &MockLunoClient_Convert_Call{Call: _e.mock.On("Convert", ctx, req)}
+}
+
+func (_c *MockLunoClient_Convert_Call) Run(run func(ctx context.Context, req *luno.ConvertRequest)) *MockLunoClient_Convert_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 *luno.ConvertRequest
+		if args[1] != nil {
+			arg1 = args[1].(*luno.ConvertRequest)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockLunoClient_Convert_Call) Return(convertResponse *luno.ConvertResponse, err error) *MockLunoClient_Convert_Call {
+	_c.Call.Return(convertResponse, err)
+	return _c
+}
+
+func (_c *MockLunoClient_Convert_Call) RunAndReturn(run func(ctx context.Context, req *luno.ConvertRequest) (*luno.ConvertResponse, error)) *MockLunoClient_Convert_Call {
+	_c.Call.Return(run)
+	return _c
+}


### PR DESCRIPTION
Adds tool support for Convert, added in https://github.com/luno/luno-go/releases/tag/v0.2.0


## For External Submissions:

- [x] Have you followed the guidelines in our [Contributing](https://github.com/luno/.github/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] If it's a non-trivial change, I've linked a new or existing [issue](../issues) to this PR
- [x] I have performed a self-review of my code
- [x] Does your submission pass existing tests?
- [x] Have you written new tests for your new changes, if applicable?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `convert` write-operation to perform account-to-account conversions when enabled.

* **Documentation**
  * Updated docs and command-line/help text to document the `convert` tool and its control via the write-operations setting (disabled by default).

* **Tests**
  * Test coverage extended to validate the new `convert` behaviour and its enabled/disabled handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->