### PR TITLE
tools: Improve tool definitions for TDQS score

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -532,7 +532,7 @@ func NewConvertTool() mcp.Tool {
 		mcp.WithTitleAnnotation("Convert between currencies"),
 		mcp.WithReadOnlyHintAnnotation(false),
 		mcp.WithDestructiveHintAnnotation(false),
-		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(false),
 		mcp.WithOpenWorldHintAnnotation(true),
 		mcp.WithOutputSchema[luno.ConvertResponse](),
 		mcp.WithString(

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -22,10 +22,56 @@ const (
 	ErrAPICredentialsRequired = "API credentials are required for this operation. Please set LUNO_API_KEY_ID and LUNO_API_SECRET environment variables."
 	ErrWriteOperationDisabled = "Write operations are disabled. To enable, restart the server with the --allow-write-operations flag or set the ALLOW_WRITE_OPERATIONS=true environment variable."
 	ErrTradingPairRequired    = "Trading pair is required"
-	ErrTradingPairDesc        = "Trading pair (e.g., XBTZAR)"
+	ErrTradingPairDesc        = "Trading pair using Luno's symbol convention (e.g. XBTZAR for BTC/ZAR, ETHZAR, XBTEUR). BTC is automatically rewritten to XBT."
+	AccountIDDesc             = "Numeric account ID, as a string (from get_balances)."
 
-	writeOperationNotice = " This is a write operation that must be explicitly enabled via the --allow-write-operations flag or ALLOW_WRITE_OPERATIONS environment variable."
+	writeOperationNotice = " Write operation: requires the --allow-write-operations flag or ALLOW_WRITE_OPERATIONS=true."
 )
+
+// EnhancedBalance is the per-account balance payload returned by get_balances.
+// It augments the raw Luno API balance with the human-friendly account name.
+type EnhancedBalance struct {
+	AccountID   string `json:"account_id"`
+	Asset       string `json:"asset"`
+	Balance     string `json:"balance"`
+	Reserved    string `json:"reserved"`
+	Unconfirmed string `json:"unconfirmed"`
+	Name        string `json:"name"`
+}
+
+// GetBalancesOutput is the structured response shape for get_balances.
+type GetBalancesOutput struct {
+	Balances []EnhancedBalance `json:"balances"`
+}
+
+// readOnlyTool composes the annotation + output-schema options shared by every
+// safe read tool: title, read-only=true, destructive=false, idempotent=true,
+// open-world=true, plus a generated output schema for T.
+func readOnlyTool[T any](title string) mcp.ToolOption {
+	return func(t *mcp.Tool) {
+		for _, opt := range []mcp.ToolOption{
+			mcp.WithTitleAnnotation(title),
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithIdempotentHintAnnotation(true),
+			mcp.WithOpenWorldHintAnnotation(true),
+			mcp.WithOutputSchema[T](),
+		} {
+			opt(t)
+		}
+	}
+}
+
+// structuredJSONResult marshals v to indented JSON for the human-readable text
+// channel and returns it alongside v as structured content. `what` names the
+// payload for the error path (e.g. "balances", "ticker").
+func structuredJSONResult(v any, what string) (*mcp.CallToolResult, error) {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal %s: %v", what, err)), nil
+	}
+	return mcp.NewToolResultStructured(v, string(b)), nil
+}
 
 // Tool IDs
 const (
@@ -50,7 +96,8 @@ const (
 func NewGetBalancesTool() mcp.Tool {
 	return mcp.NewTool(
 		GetBalancesToolID,
-		mcp.WithDescription("Get balances for all Luno accounts"),
+		mcp.WithDescription("Return balances for every account on the authenticated Luno profile, including available, reserved, and unconfirmed amounts per asset. Requires API credentials. Use this to check holdings before placing orders, conversions, or transfers; not for public market data (use get_ticker or get_tickers)."),
+		readOnlyTool[GetBalancesOutput]("Get account balances"),
 	)
 }
 
@@ -66,16 +113,6 @@ func HandleGetBalances(cfg *config.Config) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to get balances: %v", err)), nil
 		}
 
-		// Enhance the response with additional information
-		type EnhancedBalance struct {
-			AccountID   string `json:"account_id"`
-			Asset       string `json:"asset"`
-			Balance     string `json:"balance"`
-			Reserved    string `json:"reserved"`
-			Unconfirmed string `json:"unconfirmed"`
-			Name        string `json:"name"`
-		}
-
 		enhancedBalances := make([]EnhancedBalance, 0, len(balances.Balance))
 		for _, balance := range balances.Balance {
 			enhancedBalances = append(enhancedBalances, EnhancedBalance{
@@ -88,12 +125,7 @@ func HandleGetBalances(cfg *config.Config) server.ToolHandlerFunc {
 			})
 		}
 
-		resultJSON, err := json.MarshalIndent(enhancedBalances, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal balances: %v", err)), nil
-		}
-
-		return mcp.NewToolResultText(string(resultJSON)), nil
+		return structuredJSONResult(GetBalancesOutput{Balances: enhancedBalances}, "balances")
 	}
 }
 
@@ -103,7 +135,8 @@ func HandleGetBalances(cfg *config.Config) server.ToolHandlerFunc {
 func NewGetTickerTool() mcp.Tool {
 	return mcp.NewTool(
 		GetTickerToolID,
-		mcp.WithDescription("Get ticker information for a trading pair"),
+		mcp.WithDescription("Get the latest ticker (last trade price, best bid, best ask, 24h rolling volume) for a single Luno trading pair. Public endpoint, no auth required. Use this for a quick price snapshot of one market; use get_tickers for multiple markets at once, or get_order_book for depth-of-book."),
+		readOnlyTool[luno.GetTickerResponse]("Get ticker"),
 		mcp.WithString(
 			"pair",
 			mcp.Required(),
@@ -130,12 +163,7 @@ func HandleGetTicker(cfg *config.Config) server.ToolHandlerFunc {
 			return mcp.NewToolResultErrorFromErr("getting ticker", err), nil
 		}
 
-		resultJSON, err := json.MarshalIndent(ticker, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal ticker: %v", err)), nil
-		}
-
-		return mcp.NewToolResultText(string(resultJSON)), nil
+		return structuredJSONResult(ticker, "ticker")
 	}
 }
 
@@ -143,7 +171,8 @@ func HandleGetTicker(cfg *config.Config) server.ToolHandlerFunc {
 func NewGetOrderBookTool() mcp.Tool {
 	return mcp.NewTool(
 		GetOrderBookToolID,
-		mcp.WithDescription("Get order book for a trading pair"),
+		mcp.WithDescription("Return the top 100 bids and asks for a trading pair, aggregated by price level. Public endpoint, no auth required. Use this to assess available liquidity and likely slippage before sizing an order; use get_ticker for a simple price quote or list_trades for recent execution flow."),
+		readOnlyTool[luno.GetOrderBookResponse]("Get order book"),
 		mcp.WithString(
 			"pair",
 			mcp.Required(),
@@ -170,12 +199,7 @@ func HandleGetOrderBook(cfg *config.Config) server.ToolHandlerFunc {
 			return mcp.NewToolResultErrorFromErr("getting order book", err), nil
 		}
 
-		resultJSON, err := json.MarshalIndent(orderBook, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal order book: %v", err)), nil
-		}
-
-		return mcp.NewToolResultText(string(resultJSON)), nil
+		return structuredJSONResult(orderBook, "order book")
 	}
 }
 
@@ -183,10 +207,11 @@ func HandleGetOrderBook(cfg *config.Config) server.ToolHandlerFunc {
 func NewGetTickersTool() mcp.Tool {
 	return mcp.NewTool(
 		GetTickersToolID,
-		mcp.WithDescription("List tickers for all currency pairs"),
+		mcp.WithDescription("List the latest tickers for all Luno trading pairs, or for a comma-separated subset. Each ticker has last trade price, best bid, best ask, and 24h volume. Public endpoint, no auth required. Use this to survey or compare multiple markets in one call; use get_ticker when you only need a single pair."),
+		readOnlyTool[luno.GetTickersResponse]("List tickers"),
 		mcp.WithString(
 			"pair",
-			mcp.Description("Return tickers for multiple markets (e.g., XBTZAR,ETHZAR)"),
+			mcp.Description("Optional comma-separated list of pairs to filter to (e.g. \"XBTZAR,ETHZAR\"). Omit to return every supported pair."),
 		),
 	)
 }
@@ -210,12 +235,7 @@ func HandleGetTickers(cfg *config.Config) server.ToolHandlerFunc {
 			return mcp.NewToolResultErrorFromErr("getting tickers", err), nil
 		}
 
-		resultJSON, err := json.MarshalIndent(tickers, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal tickers: %v", err)), nil
-		}
-
-		return mcp.NewToolResultText(string(resultJSON)), nil
+		return structuredJSONResult(tickers, "tickers")
 	}
 }
 
@@ -223,7 +243,8 @@ func HandleGetTickers(cfg *config.Config) server.ToolHandlerFunc {
 func NewGetCandlesTool() mcp.Tool {
 	return mcp.NewTool(
 		GetCandlesToolID,
-		mcp.WithDescription("Get candlestick market data for a currency pair"),
+		mcp.WithDescription("Return OHLCV candlestick data for a trading pair. Each candle contains timestamp (ms), open, high, low, close, and base-currency volume. Public endpoint, no auth required. Use for charts, indicators, or backtesting; not for live order-book state (use get_order_book) or trade-by-trade flow (use list_trades)."),
+		readOnlyTool[luno.GetCandlesResponse]("Get candlestick data"),
 		mcp.WithString(
 			"pair",
 			mcp.Required(),
@@ -231,12 +252,14 @@ func NewGetCandlesTool() mcp.Tool {
 		),
 		mcp.WithNumber(
 			"since",
-			mcp.Description("Filter to candles starting on or after this timestamp (Unix milliseconds). Defaults to 24 hours ago."),
+			mcp.Description("Start of the window as Unix epoch milliseconds (UTC). Defaults to 24 hours ago when omitted or 0."),
+			mcp.Min(0),
 		),
 		mcp.WithNumber(
 			"duration",
 			mcp.Required(),
-			mcp.Description("Candle duration in seconds (e.g., 60 for 1m, 300 for 5m, 3600 for 1h)"),
+			mcp.Description("Candle duration in seconds. Common values: 60 (1m), 300 (5m), 900 (15m), 1800 (30m), 3600 (1h), 10800 (3h), 14400 (4h), 28800 (8h), 86400 (1d), 259200 (3d), 604800 (1w). The Luno API only accepts a fixed set of durations; passing an unsupported value will return an error."),
+			mcp.Min(60),
 		),
 	)
 }
@@ -274,12 +297,7 @@ func HandleGetCandles(cfg *config.Config) server.ToolHandlerFunc {
 			return mcp.NewToolResultErrorFromErr("getting candles", err), nil
 		}
 
-		resultJSON, err := json.MarshalIndent(candles, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal candles: %v", err)), nil
-		}
-
-		return mcp.NewToolResultText(string(resultJSON)), nil
+		return structuredJSONResult(candles, "candles")
 	}
 }
 
@@ -287,10 +305,11 @@ func HandleGetCandles(cfg *config.Config) server.ToolHandlerFunc {
 func NewGetMarketsInfoTool() mcp.Tool {
 	return mcp.NewTool(
 		GetMarketsInfoToolID,
-		mcp.WithDescription("List all supported markets parameter information"),
+		mcp.WithDescription("List supported Luno markets and their trading parameters: min/max base and counter volume, price/volume tick size, fee tiers, status, and base/counter currency. Public endpoint, no auth required. Use this before placing an order to validate price/volume against the market's tick and minimum constraints; not for live prices (use get_ticker)."),
+		readOnlyTool[luno.MarketsResponse]("List market info"),
 		mcp.WithString(
 			"pair",
-			mcp.Description("List of market pairs to return (e.g., XBTZAR,ETHZAR)"),
+			mcp.Description("Optional comma-separated list of pairs to filter to (e.g. \"XBTZAR,ETHZAR\"). Omit to return every supported market."),
 		),
 	)
 }
@@ -314,12 +333,7 @@ func HandleGetMarketsInfo(cfg *config.Config) server.ToolHandlerFunc {
 			return mcp.NewToolResultErrorFromErr("getting markets info", err), nil
 		}
 
-		resultJSON, err := json.MarshalIndent(markets, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal markets info: %v", err)), nil
-		}
-
-		return mcp.NewToolResultText(string(resultJSON)), nil
+		return structuredJSONResult(markets, "markets info")
 	}
 }
 
@@ -332,31 +346,37 @@ func HandleWriteOperationDisabled() server.ToolHandlerFunc {
 	}
 }
 
-// `volume` (amount of cryptocurrency to trade) and `price` (limit price as a decimal string).
+// NewCreateOrderTool creates a tool that posts a new GTC limit order on Luno.
 func NewCreateOrderTool() mcp.Tool {
 	return mcp.NewTool(
 		CreateOrderToolID,
-		mcp.WithDescription("Create a new limit order."+writeOperationNotice),
+		mcp.WithDescription("Place a new GTC limit order on Luno. The order rests on the book and may fill partially, fully, or not at all; this tool does not wait for or report fills - use list_orders to inspect state, or cancel_order to withdraw a working order. Not idempotent: repeated calls create duplicate orders. Prefer get_markets_info first to validate the pair's tick size and minimum volume."+writeOperationNotice),
+		mcp.WithTitleAnnotation("Create limit order"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithOutputSchema[luno.PostLimitOrderResponse](),
 		mcp.WithString(
 			"pair",
 			mcp.Required(),
-			mcp.Description("Trading pair (e.g., XBTZAR)"),
+			mcp.Description(ErrTradingPairDesc),
 		),
 		mcp.WithString(
 			"type",
 			mcp.Required(),
-			mcp.Description("Order type (BUY or SELL)"),
+			mcp.Description("Side of the order. BUY = bid (buy the base currency with the counter currency); SELL = ask (sell the base currency for the counter currency)."),
 			mcp.Enum("BUY", "SELL"),
 		),
 		mcp.WithString(
 			"volume",
 			mcp.Required(),
-			mcp.Description("Order volume (amount of cryptocurrency to buy or sell)"),
+			mcp.Description("Order volume in the base currency, as a decimal string (e.g. \"0.001\"). Must meet the market's minimum volume and step size; check get_markets_info."),
 		),
 		mcp.WithString(
 			"price",
 			mcp.Required(),
-			mcp.Description("Limit price as a decimal string"),
+			mcp.Description("Limit price in the counter currency, as a decimal string (e.g. \"500000\"). Must align with the market's tick size; check get_markets_info."),
 		),
 	)
 }
@@ -457,7 +477,7 @@ func HandleCreateOrder(cfg *config.Config) server.ToolHandlerFunc {
 
 		successMsg := fmt.Sprintf("Order created successfully!\n\n%s\n\n%s",
 			string(resultJSON), marketInfoString)
-		return mcp.NewToolResultText(successMsg), nil
+		return mcp.NewToolResultStructured(order, successMsg), nil
 	}
 }
 
@@ -466,11 +486,17 @@ func HandleCreateOrder(cfg *config.Config) server.ToolHandlerFunc {
 func NewCancelOrderTool() mcp.Tool {
 	return mcp.NewTool(
 		CancelOrderToolID,
-		mcp.WithDescription("Cancel an order."+writeOperationNotice),
+		mcp.WithDescription("Cancel a working order by ID. Idempotent at the Luno API level: cancelling an already-cancelled or fully-filled order returns the current state without error. Use after list_orders to remove a specific working order."+writeOperationNotice),
+		mcp.WithTitleAnnotation("Cancel order"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithOutputSchema[luno.StopOrderResponse](),
 		mcp.WithString(
 			"order_id",
 			mcp.Required(),
-			mcp.Description("Order ID to cancel"),
+			mcp.Description("ID of the order to cancel, as returned by list_orders or create_order."),
 		),
 	)
 }
@@ -494,12 +520,7 @@ func HandleCancelOrder(cfg *config.Config) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to cancel order: %v", err)), nil
 		}
 
-		resultJSON, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal result: %v", err)), nil
-		}
-
-		return mcp.NewToolResultText(string(resultJSON)), nil
+		return structuredJSONResult(result, "cancel order result")
 	}
 }
 
@@ -507,25 +528,32 @@ func HandleCancelOrder(cfg *config.Config) server.ToolHandlerFunc {
 func NewConvertTool() mcp.Tool {
 	return mcp.NewTool(
 		ConvertToolID,
-		mcp.WithDescription("Instantly convert between two currencies (e.g. ZAR to ZARU) using the Luno broker."+writeOperationNotice),
+		mcp.WithDescription("Instantly convert funds between two currency accounts on the authenticated profile via the Luno broker (e.g. ZAR to ZARU). The conversion is final and applies the broker quote at execution time. Pass idempotency_key to make retries safe; omitting it generates a fresh UUID per call, so retries on network error may double-convert."+writeOperationNotice),
+		mcp.WithTitleAnnotation("Convert between currencies"),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithOutputSchema[luno.ConvertResponse](),
 		mcp.WithString(
 			"source_account_id",
 			mcp.Required(),
-			mcp.Description("Account ID to convert funds from"),
+			mcp.Description("Numeric ID of the account to debit, as a string (from get_balances)."),
 		),
 		mcp.WithString(
 			"target_account_id",
 			mcp.Required(),
-			mcp.Description("Account ID to receive converted funds"),
+			mcp.Description("Numeric ID of the account to credit, as a string (from get_balances). Must hold the target currency."),
 		),
 		mcp.WithString(
 			"amount",
 			mcp.Required(),
-			mcp.Description("Decimal amount to convert (e.g. \"100.00\")"),
+			mcp.Description("Amount of the source currency to convert, as a decimal string (e.g. \"100.00\"). Must be positive."),
 		),
 		mcp.WithString(
 			"idempotency_key",
-			mcp.Description("Unique key to prevent duplicate conversions; auto-generated UUID if omitted"),
+			mcp.Description("Any unique string up to 255 chars. Reuse the same key to safely retry a failed call without double-converting. Auto-generated as a UUID when omitted."),
+			mcp.MaxLength(255),
 		),
 	)
 }
@@ -592,12 +620,7 @@ func HandleConvert(cfg *config.Config) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to convert: %v", err)), nil
 		}
 
-		resultJSON, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal result: %v", err)), nil
-		}
-
-		return mcp.NewToolResultText(string(resultJSON)), nil
+		return structuredJSONResult(result, "convert result")
 	}
 }
 
@@ -605,14 +628,18 @@ func HandleConvert(cfg *config.Config) server.ToolHandlerFunc {
 func NewListOrdersTool() mcp.Tool {
 	return mcp.NewTool(
 		ListOrdersToolID,
-		mcp.WithDescription("List open orders"),
+		mcp.WithDescription("List orders on the authenticated profile (open by default; recently completed orders may also appear depending on Luno API behaviour), optionally filtered by trading pair. Requires API credentials. Use this to inspect or audit working orders before cancelling them or placing new ones."),
+		readOnlyTool[luno.ListOrdersResponse]("List open orders"),
 		mcp.WithString(
 			"pair",
-			mcp.Description("Trading pair (e.g., XBTZAR)"),
+			mcp.Description("Optional trading pair filter (e.g. \"XBTZAR\"). Omit to list orders across all pairs."),
 		),
 		mcp.WithNumber(
 			"limit",
-			mcp.Description("Maximum number of orders to return (default: 100)"),
+			mcp.Description("Maximum number of orders to return (1-100). Defaults to 100."),
+			mcp.Min(1),
+			mcp.Max(100),
+			mcp.DefaultNumber(100),
 		),
 	)
 }
@@ -644,12 +671,7 @@ func HandleListOrders(cfg *config.Config) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to list orders: %v", err)), nil
 		}
 
-		resultJSON, err := json.MarshalIndent(orders, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal orders: %v", err)), nil
-		}
-
-		return mcp.NewToolResultText(string(resultJSON)), nil
+		return structuredJSONResult(orders, "orders")
 	}
 }
 
@@ -659,19 +681,24 @@ func HandleListOrders(cfg *config.Config) server.ToolHandlerFunc {
 func NewListTransactionsTool() mcp.Tool {
 	return mcp.NewTool(
 		ListTransactionsToolID,
-		mcp.WithDescription("List transactions for an account"),
+		mcp.WithDescription("List ledger entries for a single account on the authenticated profile, paginated by row ID. min_row is inclusive, max_row is exclusive, and the API caps a single window at 1000 rows. Requires API credentials. Use for reconciliation, exports, or audit trails; iterate by advancing min_row to (last returned row + 1)."),
+		readOnlyTool[luno.ListTransactionsResponse]("List account transactions"),
 		mcp.WithString(
 			"account_id",
 			mcp.Required(),
-			mcp.Description("Account ID"),
+			mcp.Description(AccountIDDesc),
 		),
 		mcp.WithNumber(
 			"min_row",
-			mcp.Description("Minimum row ID to return (for pagination, inclusive)"),
+			mcp.Description("First row to return, inclusive (1-based). Defaults to 1 when omitted."),
+			mcp.Min(1),
+			mcp.DefaultNumber(1),
 		),
 		mcp.WithNumber(
 			"max_row",
-			mcp.Description("Maximum row ID to return (for pagination, exclusive)"),
+			mcp.Description("Last row to return, exclusive. Defaults to 100 when omitted. The Luno API caps (max_row - min_row) at 1000."),
+			mcp.Min(1),
+			mcp.DefaultNumber(100),
 		),
 	)
 }
@@ -711,12 +738,7 @@ func HandleListTransactions(cfg *config.Config) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to list transactions: %v", err)), nil
 		}
 
-		resultJSON, err := json.MarshalIndent(transactions, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal transactions: %v", err)), nil
-		}
-
-		return mcp.NewToolResultText(string(resultJSON)), nil
+		return structuredJSONResult(transactions, "transactions")
 	}
 }
 
@@ -724,16 +746,17 @@ func HandleListTransactions(cfg *config.Config) server.ToolHandlerFunc {
 func NewGetTransactionTool() mcp.Tool {
 	return mcp.NewTool(
 		GetTransactionToolID,
-		mcp.WithDescription("Get details of a specific transaction"),
+		mcp.WithDescription("Return the full ledger entry for one transaction on the authenticated profile (amount, running balance, description, timestamp). Only finds transactions within the most recent 1000 rows of the account; for older entries, narrow the search with list_transactions first. Requires API credentials."),
+		readOnlyTool[luno.Transaction]("Get transaction details"),
 		mcp.WithString(
 			"account_id",
 			mcp.Required(),
-			mcp.Description("Account ID"),
+			mcp.Description(AccountIDDesc),
 		),
 		mcp.WithString(
 			"transaction_id",
 			mcp.Required(),
-			mcp.Description("Transaction ID"),
+			mcp.Description("Row index of the transaction within the account, as a string. Obtain from list_transactions (row_index field)."),
 		),
 	)
 }
@@ -792,12 +815,7 @@ func HandleGetTransaction(cfg *config.Config) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("Transaction not found: %s", transactionIDStr)), nil
 		}
 
-		resultJSON, err := json.MarshalIndent(transaction, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal transaction: %v", err)), nil
-		}
-
-		return mcp.NewToolResultText(string(resultJSON)), nil
+		return structuredJSONResult(transaction, "transaction")
 	}
 }
 
@@ -807,7 +825,8 @@ func HandleGetTransaction(cfg *config.Config) server.ToolHandlerFunc {
 func NewListTradesTool() mcp.Tool {
 	return mcp.NewTool(
 		ListTradesToolID,
-		mcp.WithDescription("List recent trades for a currency pair"),
+		mcp.WithDescription("List recent public trades for a trading pair, with price, volume, side (BUY/SELL), and timestamp. Public endpoint, no auth required. Use for recent execution flow or tape analysis; not for your own trade history."),
+		readOnlyTool[luno.ListTradesResponse]("List recent trades"),
 		mcp.WithString(
 			"pair",
 			mcp.Required(),
@@ -815,7 +834,7 @@ func NewListTradesTool() mcp.Tool {
 		),
 		mcp.WithString(
 			"since",
-			mcp.Description("Fetch trades executed after this timestamp (Unix milliseconds)"),
+			mcp.Description("Optional lower bound as Unix epoch milliseconds (UTC), passed as a string. Only trades executed after this time are returned. Omit for the most recent trades."),
 		),
 	)
 }
@@ -855,12 +874,7 @@ func HandleListTrades(cfg *config.Config) server.ToolHandlerFunc {
 			return mcp.NewToolResultErrorFromErr("listing trades", err), nil
 		}
 
-		resultJSON, err := json.MarshalIndent(trades, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal trades: %v", err)), nil
-		}
-
-		return mcp.NewToolResultText(string(resultJSON)), nil
+		return structuredJSONResult(trades, "trades")
 	}
 }
 

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -332,10 +332,10 @@ func TestHandleGetBalances(t *testing.T) {
 				assert.NotEmpty(t, textContent)
 
 				// Verify JSON structure
-				var balances []map[string]any
-				err := json.Unmarshal([]byte(textContent), &balances)
+				var output GetBalancesOutput
+				err := json.Unmarshal([]byte(textContent), &output)
 				assert.NoError(t, err)
-				assert.Len(t, balances, 2, "Should have 2 balances")
+				assert.Len(t, output.Balances, 2, "Should have 2 balances")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Glama's [Tool Definition Quality Score](https://glama.ai/blog/2026-04-03-tool-definition-quality-score-tdqs) rated [luno-mcp](https://glama.ai/mcp/servers/luno/luno-mcp/score) at **83% (B tier)** with individual tools at **2.7–3.3 / 5.0**. The dominant defect was that every tool inherited mcp-go's default annotations (`readOnly=false`, `destructive=true`), contradicting the descriptions of safe read operations.

This PR fixes that surface across the board:

- **Annotations**: every tool now sets explicit `Title`, `ReadOnly`, `Destructive`, `Idempotent`, `OpenWorld` hints. `create_order` is non-destructive (adds new state); `cancel_order` is destructive + idempotent; `convert` is idempotent when `idempotency_key` is supplied.
- **Descriptions**: rewritten using a four-part template - purpose, behaviour/return shape, when-to-use vs. not, auth + format notes. Differentiates `get_ticker` ↔ `get_tickers`, `list_orders` ↔ `list_transactions`, etc.
- **Parameter semantics**: format hints, ranges, and defaults via `mcp.Min/Max/DefaultNumber/MaxLength`.
- **Output schemas**: `WithOutputSchema[T]()` on all 13 tools using luno-go SDK response types, plus a new `GetBalancesOutput` wrapper that promotes the previously inline `EnhancedBalance` struct to package level.
- **Structured content**: handlers migrated from `NewToolResultText` to `NewToolResultStructured` so the declared schemas are honoured at runtime - same text fallback, plus typed structured content for schema-aware clients.
- **Reuse**: extracted `readOnlyTool[T]` and `structuredJSONResult` helpers + `AccountIDDesc` constant to collapse the repetition this would otherwise have introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardised response formatting across all trading tools for consistent, structured JSON output.

* **Documentation**
  * Enhanced tool descriptions with detailed parameter documentation and usage guidance.
  * Improved clarity on trading pair conventions and operation behaviour (idempotency, pagination).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->