### PR TITLE
docker: Default container to stdio transport

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,17 @@ name: Docker Publish
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'cmd/**'
+      - 'internal/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '.github/workflows/docker-publish.yml'
   push:
     branches:
       - main
@@ -13,6 +24,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - 'Dockerfile'
+      - '.dockerignore'
       - '.github/workflows/docker-publish.yml'
 
 jobs:
@@ -64,6 +76,27 @@ jobs:
             [ "${{ github.event_name }}" != "pull_request" ] && echo "type=registry,ref=ghcr.io/${{ github.repository }}/cache:buildcache,mode=max"
             echo "EOF"
           } >> $GITHUB_OUTPUT
+
+      # Smoke-test the stdio handshake before pushing - the multi-arch publish
+      # below would otherwise ship a container that times out under mcp-proxy.
+      - name: Build image for stdio smoke test
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64
+          load: true
+          tags: luno-mcp:smoke-test
+          cache-from: type=gha
+
+      - name: Stdio handshake smoke test
+        run: |
+          set -euo pipefail
+          req='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci-smoke","version":"0.0.1"}}}'
+          response=$(printf '%s\n' "$req" \
+            | timeout 20 docker run --rm -i luno-mcp:smoke-test 2>/dev/null \
+            | head -n 1)
+          echo "Response: $response"
+          echo "$response" | jq -e '.jsonrpc == "2.0" and .id == 1 and .result != null' > /dev/null
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,17 +37,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to the Container registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -80,7 +80,7 @@ jobs:
       # Smoke-test the stdio handshake before pushing - the multi-arch publish
       # below would otherwise ship a container that times out under mcp-proxy.
       - name: Build image for stdio smoke test
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64
@@ -99,7 +99,7 @@ jobs:
           echo "$response" | jq -e '.jsonrpc == "2.0" and .id == 1 and .result != null' > /dev/null
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: true
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
             goarch: arm64
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: true
@@ -42,7 +42,7 @@ jobs:
           go build -ldflags="-s -w" -o luno-mcp ./cmd/server
           tar czf luno-mcp-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz luno-mcp
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: luno-mcp-${{ matrix.goos }}-${{ matrix.goarch }}
           path: luno-mcp-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
@@ -55,7 +55,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist/
           merge-multiple: true

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -16,10 +16,10 @@ jobs:
       pull-requests: write
       checks: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
 
@@ -31,7 +31,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
         if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
-        uses: SonarSource/sonarqube-scan-action@v8.0.0
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
         with:
           args: >
             -Dsonar.token=${{ secrets.SONAR_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,3 +30,6 @@ COPY --from=builder /luno-mcp /luno-mcp
 USER app
 
 ENTRYPOINT ["/luno-mcp"]
+# Container clients (Glama, Claude Desktop, VS Code) pipe JSON-RPC over stdio;
+# the binary CLI default is streamable-http which makes them hang.
+CMD ["--transport=stdio"]

--- a/cmd/server/stdio_handshake_test.go
+++ b/cmd/server/stdio_handshake_test.go
@@ -95,7 +95,14 @@ func buildServerBinary(t *testing.T) string {
 	require.NoError(t, err)
 	repoRoot := filepath.Clean(filepath.Join(wd, "..", ".."))
 
-	cmd := exec.Command("go", "build", "-o", binPath, "./cmd/server")
+	ctx := context.Background()
+	if deadline, ok := t.Deadline(); ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(ctx, deadline)
+		t.Cleanup(cancel)
+	}
+
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", binPath, "./cmd/server")
 	cmd.Dir = repoRoot
 	out, err := cmd.CombinedOutput()
 	require.NoErrorf(t, err, "go build failed: %s", string(out))

--- a/cmd/server/stdio_handshake_test.go
+++ b/cmd/server/stdio_handshake_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStdioHandshake guards the Glama / Claude Desktop / VS Code integration:
+// the container is launched with no args and must respond to a JSON-RPC
+// initialize on stdio. A non-stdio default transport silently hangs the proxy
+// instead of failing the build.
+func TestStdioHandshake(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping stdio handshake test in -short mode (builds binary)")
+	}
+
+	binPath := buildServerBinary(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, binPath, "--transport="+testTransportStdio)
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	stdout, err := cmd.StdoutPipe()
+	require.NoError(t, err)
+	cmd.Stderr = &stderr
+
+	require.NoError(t, cmd.Start())
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		if t.Failed() && stderr.Len() > 0 {
+			t.Logf("server stderr:\n%s", stderr.String())
+		}
+	})
+
+	initReq := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"stdio-handshake-test","version":"0.0.1"}}}` + "\n"
+	_, err = stdin.Write([]byte(initReq))
+	require.NoError(t, err)
+
+	type readResult struct {
+		line string
+		err  error
+	}
+	lines := make(chan readResult, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		// MCP responses can exceed bufio's default 64KiB line buffer.
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		if scanner.Scan() {
+			lines <- readResult{line: scanner.Text()}
+			return
+		}
+		lines <- readResult{err: scanner.Err()}
+	}()
+
+	select {
+	case res := <-lines:
+		require.NoError(t, res.err, "scanner error")
+		require.NotEmpty(t, res.line, "expected a JSON-RPC response line on stdout")
+
+		var resp struct {
+			JSONRPC string          `json:"jsonrpc"`
+			ID      json.RawMessage `json:"id"`
+			Result  json.RawMessage `json:"result"`
+			Error   json.RawMessage `json:"error"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(res.line), &resp), "response not valid JSON: %s", res.line)
+		assert.Equal(t, "2.0", resp.JSONRPC)
+		assert.JSONEq(t, "1", string(resp.ID))
+		assert.NotEmpty(t, resp.Result, "expected result field; got error=%s", string(resp.Error))
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for stdio response: %v", ctx.Err())
+	}
+}
+
+func buildServerBinary(t *testing.T) string {
+	t.Helper()
+
+	binPath := filepath.Join(t.TempDir(), "luno-mcp-test")
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	repoRoot := filepath.Clean(filepath.Join(wd, "..", ".."))
+
+	cmd := exec.Command("go", "build", "-o", binPath, "./cmd/server")
+	cmd.Dir = repoRoot
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "go build failed: %s", string(out))
+	return binPath
+}


### PR DESCRIPTION
## Summary

Fixes the Glama integration failure where the container starts up but is killed
60s later when mcp-proxy times out waiting for a JSON-RPC response on stdio.

**Root cause:** the binary defaults to `--transport=streamable-http`, which binds
to `localhost:8080` and doesn't read stdin. Every documented container client
(Glama, Claude Desktop, VS Code, Cursor, Claude Code) launches the image with
`docker run -i` and pipes JSON-RPC over stdio - none of them set `--transport`,
so they all hit the same timeout.

**Fix:** add `CMD ["--transport=stdio"]` to the Dockerfile. Containers now
default to stdio; the binary CLI default and the existing SSE example in the
README are unchanged (`docker run img --transport=sse ...` still overrides CMD).

## Regression guards

- `cmd/server/stdio_handshake_test.go` builds the binary, execs it with
  `--transport=stdio`, pipes an MCP `initialize`, and asserts a valid response
  within 15s. Runs in ~1s under `go test ./...`.
- A new step in `.github/workflows/docker-publish.yml` builds an amd64 image
  with `--load`, then pipes `initialize` through `docker run -i` and validates
  the response with `jq` - mirroring exactly what Glama does.
- The workflow also now triggers on `pull_request` (the push-suppression logic
  was already in place but no PR trigger was wired up).

## Test plan

- [x] `go test ./...` passes
- [x] Local `docker buildx build --platform linux/amd64` smoke test passes
- [x] Confirmed regression: a container started with `--transport=streamable-http`
      override fails the smoke test (empty / non-JSON stdout)
- [ ] Verify Glama re-runs and goes green once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker image now provides a default command to run using stdio-based transport.

* **Tests**
  * Added an integration smoke test validating the stdio JSON‑RPC handshake between container and client.
  * Added a local integration test to verify stdio handshake behaviour.

* **Chores**
  * CI workflows updated to pin third‑party actions and refine workflow triggers and path filters for reproducible runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->