### PR TITLE
cmd/server: Default --transport flag to stdio

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ API credentials and runtime options:
 - `ALLOW_WRITE_OPERATIONS` - same effect as `--allow-write-operations` flag
 - `.env` and `../.env` are auto-loaded at startup via godotenv (dev convenience only; MCP clients pass credentials via their own input mechanism)
 
-CLI flags: `--transport` (stdio/sse/streamable-http, default `streamable-http`), `--sse-address` (default `localhost:8080`), `--domain`, `--log-level` (debug/info/warn/error), `--allow-write-operations`.
+CLI flags: `--transport` (stdio/sse/streamable-http, default `stdio`), `--sse-address` (default `localhost:8080`), `--domain`, `--log-level` (debug/info/warn/error), `--allow-write-operations`.
 
 ## Release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,3 @@ COPY --from=builder /luno-mcp /luno-mcp
 USER app
 
 ENTRYPOINT ["/luno-mcp"]
-# Container clients (Glama, Claude Desktop, VS Code) pipe JSON-RPC over stdio;
-# the binary CLI default is streamable-http which makes them hang.
-CMD ["--transport=stdio"]

--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@ Optional environment variables:
 
 ## Command-line options
 
-- `--transport`: Transport type (`stdio`, `sse`, or `streamable-http`; default: `streamable-http`)
+- `--transport`: Transport type (`stdio`, `sse`, or `streamable-http`; default: `stdio`)
 - `--sse-address`: Address for SSE and Streamable HTTP transports (default: `localhost:8080`)
 - `--domain`: Luno API domain (default: `api.luno.com`)
 - `--log-level`: Log level (`debug`, `info`, `warn`, `error`, default: `info`)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -58,7 +58,7 @@ func loadEnvFile() bool {
 
 // parseFlags parses command line flags and returns CliFlags struct
 func parseFlags() CliFlags {
-	transportType := flag.String("transport", "streamable-http", "Transport type (stdio, sse, or streamable-http)")
+	transportType := flag.String("transport", "stdio", "Transport type (stdio, sse, or streamable-http)")
 	sseAddr := flag.String("sse-address", "localhost:8080", "Address for SSE and Streamable HTTP transports")
 	lunoDomain := flag.String("domain", "", "Luno API domain (default: api.luno.com)")
 	logLevel := flag.String("log-level", "info", "Log level (debug, info, warn, error)")

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -89,7 +89,7 @@ func TestParseFlags(t *testing.T) {
 			name: "default flags",
 			args: []string{},
 			expected: CliFlags{
-				TransportType:        testTransportStreamableHTTP,
+				TransportType:        testTransportStdio,
 				SSEAddr:              testDefaultSSEAddr,
 				LunoDomain:           "",
 				LogLevel:             testLogLevelInfo,
@@ -133,7 +133,7 @@ func TestParseFlags(t *testing.T) {
 			name: "allow write operations flag",
 			args: []string{"-allow-write-operations=true"},
 			expected: CliFlags{
-				TransportType:        testTransportStreamableHTTP,
+				TransportType:        testTransportStdio,
 				SSEAddr:              testDefaultSSEAddr,
 				LunoDomain:           "",
 				LogLevel:             testLogLevelInfo,
@@ -399,7 +399,7 @@ func TestMainFunctionFlow(t *testing.T) {
 		os.Args = []string{"cmd"}
 
 		flags := parseFlags()
-		assert.Equal(t, testTransportStreamableHTTP, flags.TransportType)
+		assert.Equal(t, testTransportStdio, flags.TransportType)
 		assert.Equal(t, testDefaultSSEAddr, flags.SSEAddr)
 		assert.Equal(t, "", flags.LunoDomain)
 		assert.Equal(t, testLogLevelInfo, flags.LogLevel)

--- a/cmd/server/stdio_handshake_test.go
+++ b/cmd/server/stdio_handshake_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // TestStdioHandshake guards the Glama / Claude Desktop / VS Code integration:
-// the container is launched with no args and must respond to a JSON-RPC
+// the binary is launched with no args and must respond to a JSON-RPC
 // initialize on stdio. A non-stdio default transport silently hangs the proxy
 // instead of failing the build.
 func TestStdioHandshake(t *testing.T) {
@@ -30,7 +30,7 @@ func TestStdioHandshake(t *testing.T) {
 	defer cancel()
 
 	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, binPath, "--transport="+testTransportStdio)
+	cmd := exec.CommandContext(ctx, binPath)
 	stdin, err := cmd.StdinPipe()
 	require.NoError(t, err)
 	stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
## Summary

- Flips the binary's CLI `--transport` default from `streamable-http` to `stdio` so that container-based MCP clients (Glama, Claude Desktop, VS Code, anything invoking via `mcp-proxy`) work out of the box with no args.
- Removes the now-redundant `CMD ["--transport=stdio"]` from our Dockerfile - the binary handles it now.
- Drops the explicit `--transport=stdio` arg from `TestStdioHandshake` so the test exercises the actual no-args default path that Glama and `mcp-proxy ./luno-mcp` rely on.

## Context

#124 tried to fix this in our Dockerfile by setting `CMD ["--transport=stdio"]`, but Glama's [latest build-spec test](https://glama.ai/mcp/servers/@luno/luno-mcp/admin/dockerfile/tests/019e3bbe-b031-7df9-8e73-82f117c2ddcb) still fails because Glama auto-generates its own Dockerfile from our repo (`CMD ["mcp-proxy", "./luno-mcp"]`) and never invokes ours. With no args, the binary fell back to `streamable-http` and `mcp-proxy` timed out:

```
Error: MCP error -32001: Request timed out
Error: Container exited with code 1 before responding to ping
```

Moving the default into the binary itself fixes Glama, the Docker image, and any other client that runs `luno-mcp` with no args.

## Test plan

- [x] `go test ./...` - all green
- [x] Local smoke: `printf '{"jsonrpc":"2.0","id":1,"method":"initialize",...}\n' | ./luno-mcp` returns a valid initialize response on stdout with logs cleanly on stderr
- [x] `TestStdioHandshake` now invokes the binary with no args and still passes (guards the Glama default-args path)
- [ ] CI: stdio handshake smoke step in `docker-publish.yml` (`docker run --rm -i luno-mcp:smoke-test`) - already relies on no-args invocation, will now exercise the binary default rather than the Dockerfile CMD

## Notes

Anyone running streamable-HTTP or SSE will need `--transport=streamable-http` / `--transport=sse` explicitly. The `make run-streamable-http` and `make run-sse` targets already pass the flag; `make run-stdio` now matches its name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated command-line flag documentation to reflect the new default transport mechanism.

* **Configuration**
  * Container configuration updated; transport mechanism now configurable at runtime rather than using a hardcoded default.

* **Tests**
  * Updated test expectations to align with the new default transport configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->