### PR TITLE
docs: Add Glama MCP server score badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=luno_luno-mcp&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=luno_luno-mcp)
 [![Go Report Card](https://goreportcard.com/badge/github.com/luno/luno-mcp)](https://goreportcard.com/report/github.com/luno/luno-mcp)
 [![GoDoc](https://godoc.org/github.com/luno/luno-mcp?status.svg)](https://godoc.org/github.com/luno/luno-mcp)
+[![luno-mcp MCP server](https://glama.ai/mcp/servers/luno/luno-mcp/badges/score.svg)](https://glama.ai/mcp/servers/luno/luno-mcp)
 
 A [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that provides access to the Luno cryptocurrency exchange API.
 


### PR DESCRIPTION
## Summary
- Adds the Glama MCP server score badge to the README badge row, linking to the server's listing on glama.ai.

## Test plan
- [ ] README renders with the new badge alongside the existing Sonar / Go Report Card / GoDoc badges on GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added a Glama badge to the project README, displayed alongside existing quality and status badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->