### PR TITLE
tools: Fix output schema for decimal.Decimal and luno.Time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 tool github.com/vektra/mockery/v3
 
 require (
+	github.com/google/jsonschema-go v0.4.2
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/luno/luno-go v0.2.0
@@ -19,7 +20,6 @@ require (
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jedib0t/go-pretty/v6 v6.7.8 // indirect

--- a/internal/tools/schema.go
+++ b/internal/tools/schema.go
@@ -1,0 +1,39 @@
+package tools
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/luno/luno-go"
+	"github.com/luno/luno-go/decimal"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// outputSchemaTypes patches the reflection-based schema generator for Luno SDK
+// types whose custom MarshalJSON emits a primitive. Without these overrides,
+// google/jsonschema-go (used by mcp-go's WithOutputSchema) sees structs with
+// no exported fields and emits {type: "object"}, so the runtime value -- a
+// string like "100.50" -- fails validation on strict clients.
+var outputSchemaTypes = map[reflect.Type]*jsonschema.Schema{
+	reflect.TypeFor[decimal.Decimal](): {Type: "string"},
+	reflect.TypeFor[luno.Time]():       {Types: []string{"null", "string"}},
+}
+
+// withOutputSchema is a drop-in for mcp.WithOutputSchema[T] that applies the
+// outputSchemaTypes overrides. Falls back to the stock helper if generation
+// or marshalling fails, so we never silently drop the schema.
+func withOutputSchema[T any]() mcp.ToolOption {
+	schema, err := jsonschema.For[T](&jsonschema.ForOptions{
+		IgnoreInvalidTypes: true,
+		TypeSchemas:        outputSchemaTypes,
+	})
+	if err != nil {
+		return mcp.WithOutputSchema[T]()
+	}
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		return mcp.WithOutputSchema[T]()
+	}
+	return mcp.WithRawOutputSchema(raw)
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -55,7 +55,7 @@ func readOnlyTool[T any](title string) mcp.ToolOption {
 			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithIdempotentHintAnnotation(true),
 			mcp.WithOpenWorldHintAnnotation(true),
-			mcp.WithOutputSchema[T](),
+			withOutputSchema[T](),
 		} {
 			opt(t)
 		}
@@ -356,7 +356,7 @@ func NewCreateOrderTool() mcp.Tool {
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(false),
 		mcp.WithOpenWorldHintAnnotation(true),
-		mcp.WithOutputSchema[luno.PostLimitOrderResponse](),
+		withOutputSchema[luno.PostLimitOrderResponse](),
 		mcp.WithString(
 			"pair",
 			mcp.Required(),
@@ -492,7 +492,7 @@ func NewCancelOrderTool() mcp.Tool {
 		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(true),
-		mcp.WithOutputSchema[luno.StopOrderResponse](),
+		withOutputSchema[luno.StopOrderResponse](),
 		mcp.WithString(
 			"order_id",
 			mcp.Required(),
@@ -534,7 +534,7 @@ func NewConvertTool() mcp.Tool {
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(false),
 		mcp.WithOpenWorldHintAnnotation(true),
-		mcp.WithOutputSchema[luno.ConvertResponse](),
+		withOutputSchema[luno.ConvertResponse](),
 		mcp.WithString(
 			"source_account_id",
 			mcp.Required(),

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1836,3 +1836,39 @@ func TestHandleConvert(t *testing.T) {
 		})
 	}
 }
+
+// TestOutputSchemaDecimalAndTime locks in that schema overrides for the Luno
+// SDK's primitive-marshalled types (decimal.Decimal -> string,
+// luno.Time -> ["null","string"]) survive. Without these, strict clients
+// reject every order book entry, ticker, candle, etc.
+func TestOutputSchemaDecimalAndTime(t *testing.T) {
+	t.Parallel()
+
+	tool := NewGetOrderBookTool()
+	require := assert.New(t)
+	require.NotNil(tool.RawOutputSchema, "expected RawOutputSchema to be set via withOutputSchema")
+
+	var schema map[string]any
+	require.NoError(json.Unmarshal(tool.RawOutputSchema, &schema))
+
+	props, _ := schema["properties"].(map[string]any)
+	for _, side := range []string{"asks", "bids"} {
+		arr, _ := props[side].(map[string]any)
+		items, _ := arr["items"].(map[string]any)
+		entryProps, _ := items["properties"].(map[string]any)
+		for _, field := range []string{"price", "volume"} {
+			f, _ := entryProps[field].(map[string]any)
+			assert.Equal(t, "string", f["type"], "%s/%s should be string, not object", side, field)
+		}
+	}
+
+	// And a quick smoke test for luno.Time on a tool that uses it.
+	txTool := NewListTransactionsTool()
+	require.NotNil(txTool.RawOutputSchema)
+	var txSchema map[string]any
+	require.NoError(json.Unmarshal(txTool.RawOutputSchema, &txSchema))
+	// Just assert no nested struct shows up as a bare {type: "object"} where a
+	// timestamp is expected - if we regress, the JSON below will contain it.
+	rendered, _ := json.Marshal(txSchema)
+	assert.NotContains(t, string(rendered), `"timestamp":{"type":"object"`)
+}

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1844,31 +1844,81 @@ func TestHandleConvert(t *testing.T) {
 func TestOutputSchemaDecimalAndTime(t *testing.T) {
 	t.Parallel()
 
-	tool := NewGetOrderBookTool()
-	require := assert.New(t)
-	require.NotNil(tool.RawOutputSchema, "expected RawOutputSchema to be set via withOutputSchema")
-
-	var schema map[string]any
-	require.NoError(json.Unmarshal(tool.RawOutputSchema, &schema))
-
-	props, _ := schema["properties"].(map[string]any)
-	for _, side := range []string{"asks", "bids"} {
-		arr, _ := props[side].(map[string]any)
-		items, _ := arr["items"].(map[string]any)
-		entryProps, _ := items["properties"].(map[string]any)
-		for _, field := range []string{"price", "volume"} {
-			f, _ := entryProps[field].(map[string]any)
-			assert.Equal(t, "string", f["type"], "%s/%s should be string, not object", side, field)
-		}
+	tests := []struct {
+		name    string
+		factory func() mcp.Tool
+		check   func(t *testing.T, schema map[string]any)
+	}{
+		{
+			name:    "GetOrderBook price/volume are strings",
+			factory: NewGetOrderBookTool,
+			check: func(t *testing.T, schema map[string]any) {
+				props, _ := schema["properties"].(map[string]any)
+				for _, side := range []string{"asks", "bids"} {
+					arr, _ := props[side].(map[string]any)
+					items, _ := arr["items"].(map[string]any)
+					entryProps, _ := items["properties"].(map[string]any)
+					for _, field := range []string{"price", "volume"} {
+						f, _ := entryProps[field].(map[string]any)
+						assert.Equal(t, "string", f["type"], "%s/%s should be string, not object", side, field)
+					}
+				}
+			},
+		},
+		{
+			name:    "ListTransactions timestamp is null|string",
+			factory: NewListTransactionsTool,
+			check: func(t *testing.T, schema map[string]any) {
+				assertTimeFieldSchema(t, schema, "transactions", "timestamp")
+			},
+		},
 	}
 
-	// And a quick smoke test for luno.Time on a tool that uses it.
-	txTool := NewListTransactionsTool()
-	require.NotNil(txTool.RawOutputSchema)
-	var txSchema map[string]any
-	require.NoError(json.Unmarshal(txTool.RawOutputSchema, &txSchema))
-	// Just assert no nested struct shows up as a bare {type: "object"} where a
-	// timestamp is expected - if we regress, the JSON below will contain it.
-	rendered, _ := json.Marshal(txSchema)
-	assert.NotContains(t, string(rendered), `"timestamp":{"type":"object"`)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tool := tt.factory()
+			assert.NotNil(t, tool.RawOutputSchema, "expected RawOutputSchema to be set via withOutputSchema")
+
+			var schema map[string]any
+			assert.NoError(t, json.Unmarshal(tool.RawOutputSchema, &schema))
+			tt.check(t, schema)
+		})
+	}
+}
+
+// assertTimeFieldSchema walks schema.properties[arrayProp].items.properties[field]
+// and verifies its "type" resolves to either "string" or ["null","string"].
+// This is stricter than a substring check: a regression that leaves type as
+// "object" with extra keys would still fail here.
+func assertTimeFieldSchema(t *testing.T, schema map[string]any, arrayProp, field string) {
+	t.Helper()
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing root properties")
+	}
+	arr, ok := props[arrayProp].(map[string]any)
+	if !ok {
+		t.Fatalf("missing %q property", arrayProp)
+	}
+	items, ok := arr["items"].(map[string]any)
+	if !ok {
+		t.Fatalf("%q has no items schema", arrayProp)
+	}
+	itemProps, ok := items["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("%q items has no properties", arrayProp)
+	}
+	target, ok := itemProps[field].(map[string]any)
+	if !ok {
+		t.Fatalf("missing %s.items.properties.%s", arrayProp, field)
+	}
+	switch v := target["type"].(type) {
+	case string:
+		assert.Equal(t, "string", v, "%s.%s should be string, not %q", arrayProp, field, v)
+	case []any:
+		assert.ElementsMatch(t, []any{"null", "string"}, v, "%s.%s should be [null,string]", arrayProp, field)
+	default:
+		t.Fatalf("%s.%s has unexpected type schema: %T (%v)", arrayProp, field, target["type"], target["type"])
+	}
 }


### PR DESCRIPTION
## Summary
- Strict MCP clients (Glama, MCP Inspector with validation enabled) reject every `get_order_book` response with errors like `data/asks/0/price must be object`, because mcp-go's reflection-based `WithOutputSchema[T]` sees `luno.OrderBookEntry.Price`/`Volume` (and any `luno.Time` field) as `{type: "object"}` even though their custom `MarshalJSON` emits a JSON string.
- This affects every tool whose schema-typed output contains a `decimal.Decimal` or `luno.Time` field - `get_ticker`, `get_tickers`, `get_order_book`, `get_candles`, `list_trades`, `list_orders`, `list_transactions`, `convert`, `create_order`, `cancel_order`. Our server doesn't enable `WithOutputSchemaValidation`, so it surfaced only on strict clients - the payload on the wire was wrong everywhere.

## Fix
- New `withOutputSchema[T]` helper in `internal/tools/schema.go` that calls `jsonschema.For[T]` with `ForOptions.TypeSchemas` registering:
  - `decimal.Decimal` → `{type: "string"}`
  - `luno.Time`       → `{type: ["null", "string"]}`
- The four call sites (`readOnlyTool` plus the three direct write-tool sites) now use the helper.
- Added a regression test in `tools_test.go` that locks in the schema shape for `price`/`volume` and checks no `timestamp` field shows up as `{type: "object"}`.

## Why not fix in luno-go?
`google/jsonschema-go` (the generator behind `mcp.WithOutputSchema`) maps types purely by `reflect.Type` against an internal stdlib map or a caller-supplied `ForOptions.TypeSchemas`. It does not auto-detect `json.Marshaler` and exposes no `JSONSchema()` interface hook, so a method on `decimal.Decimal` would be ignored.

## Upstream follow-up
Raised against `google/jsonschema-go`:
- Issue: https://github.com/google/jsonschema-go/issues/77 — proposes auto-detecting `json.Marshaler` primitive types, or adding a `Schemer` / `JSONSchema()` interface hook.
- PR: https://github.com/google/jsonschema-go/pull/78 — implementation of the `Schemer` interface option.

If either lands upstream we can drop the `TypeSchemas` map in this PR and let the generator pick the right schema automatically.

## Test plan
- [x] `make test` passes
- [x] Schema dump for `luno.GetOrderBookResponse` now emits `"type": "string"` for `price`/`volume`
- [ ] Verify against Glama after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced schema handling for accurate tool output generation with improved validation support.

* **Tests**
  * Added comprehensive validation tests for tool output schema generation to ensure correctness.

* **Chores**
  * Updated dependency versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->