### PR TITLE
tools: Mark convert tool as destructive

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -531,7 +531,7 @@ func NewConvertTool() mcp.Tool {
 		mcp.WithDescription("Instantly convert funds between two currency accounts on the authenticated profile via the Luno broker (e.g. ZAR to ZARU). The conversion is final and applies the broker quote at execution time. Pass idempotency_key to make retries safe; omitting it generates a fresh UUID per call, so retries on network error may double-convert."+writeOperationNotice),
 		mcp.WithTitleAnnotation("Convert between currencies"),
 		mcp.WithReadOnlyHintAnnotation(false),
-		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithIdempotentHintAnnotation(false),
 		mcp.WithOpenWorldHintAnnotation(true),
 		withOutputSchema[luno.ConvertResponse](),


### PR DESCRIPTION
## Summary

- The `convert` tool executes an immediate, irreversible broker FX conversion
- Its `destructiveHint` annotation was `false`, which incorrectly signals to MCP clients that the operation is safe to run without confirmation
- Changed to `true` so clients can apply appropriate risk controls (e.g. confirmation prompts)

## Context

The `cancel_order` tool is already correctly annotated as destructive. This brings `convert` in line with the same reasoning: the operation permanently alters account balances and cannot be undone.

The `convert` tool description already calls this out explicitly: *"The conversion is final"* and warns about double-conversion on retry without an idempotency key.

## Test plan

- [x] `make test` passes
- [x] Annotation verified against `cancel_order` (the established pattern for irreversible write tools)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The convert operation is now correctly identified as a destructive action, ensuring appropriate handling and user warnings are applied when executing this functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->